### PR TITLE
feat: add handling for comma maps inside braces

### DIFF
--- a/docs/swhkdrc
+++ b/docs/swhkdrc
@@ -31,6 +31,9 @@ super + ctrl + alt + {Left\
   } \
   bspc node --resize $d1 $dx $dy || bspc node --resize $d2 $dx $dy
 
+super + {\,, .}
+  bspc node -f {next.local,prev.local}
+
 # screenshot
 print
 	scrot

--- a/src/tests.rs
+++ b/src/tests.rs
@@ -978,6 +978,29 @@ super + {comma, period}
             ],
         )
     }
+
+    #[test]
+    fn test_period_escape_binding() -> std::io::Result<()> {
+        let contents = "
+super + {\\,, .}
+	riverctl focus-output {previous, next}";
+
+        eval_config_test(
+            contents,
+            vec![
+                Hotkey::new(
+                    evdev::Key::KEY_COMMA,
+                    vec![Modifier::Super],
+                    "riverctl focus-output previous".to_string(),
+                ),
+                Hotkey::new(
+                    evdev::Key::KEY_DOT,
+                    vec![Modifier::Super],
+                    "riverctl focus-output next".to_string(),
+                ),
+            ],
+        )
+    }
 }
 
 mod test_config_display {


### PR DESCRIPTION
Fixes #56

Add support for the following command mapping:

```
super + {\,, .}
```

Which is the same as:

```
super + {comma, .}
```

Because the brace syntax uses commas to separate tokens, `,` must be escaped with a backslash to be used as a keysym.