### PR TITLE
Update release.sh

### DIFF
--- a/release.sh
+++ b/release.sh
@@ -1,4 +1,5 @@
 #!/bin/bash
+rm Cargo.lock  # Ensures that features and dependencies are fine when we cargo update and to sync with breaking changes
 version=$(awk -F = '/^version/ {print $2}' Cargo.toml | awk '{$1=$1;print}' | tr -d '"')
 make
 cd bin


### PR DESCRIPTION
Cargo.lock is good if we want to keep the latest successful builds. However, if there are updates from dependencies, we might need to test if it builds correctly with the project. If it does, we can commit the newly generated Cargo.lock and keep it there.

EDIT: not sure how we add the Cargo.lock after a successful build though :woozy_face: 