### PR TITLE
Support for the xdg runtime dir variable has already been added in the daemon but not the server.

### DIFF
--- a/src/server.rs
+++ b/src/server.rs
@@ -11,6 +11,27 @@ use std::{
 };
 use sysinfo::{ProcessExt, System, SystemExt};
 
+fn get_file_paths() -> (String, String) {
+    match env::var("XDG_RUNTIME_DIR") {
+        Ok(val) => {
+            log::info!("XDG_RUNTIME_DIR Variable is present, using it's value as default file path.");
+
+            let pid_file_path = String::from(format!("{}/swhks.pid", val));
+            let sock_file_path = String::from(format!("{}/swhkd.sock", val));
+            
+            return (pid_file_path, sock_file_path);
+        }
+        Err(e) => {
+            log::trace!("XDG_RUNTIME_DIR Variable is not set, falling back on hardcoded path.\nError: {:#?}", e);
+
+            let pid_file_path = String::from(format!("/run/user/{}/swhks.pid", unistd::Uid::current()));
+            let sock_file_path = String::from(format!("/run/user/{}/swhkd.sock", unistd::Uid::current()));
+
+            return (pid_file_path, sock_file_path);
+        }    
+    }
+}
+
 fn main() -> std::io::Result<()> {
     env::set_var("RUST_LOG", "swhks=trace");
     env_logger::init();
@@ -18,8 +39,7 @@ fn main() -> std::io::Result<()> {
     log::trace!("Setting process umask.");
     umask(Mode::S_IWGRP | Mode::S_IWOTH);
 
-    let pid_file_path = String::from(format!("/run/user/{}/swhks.pid", unistd::Uid::current()));
-    let sock_file_path = String::from(format!("/run/user/{}/swhkd.sock", unistd::Uid::current()));
+    let (pid_file_path, sock_file_path) = get_file_paths();
 
     if Path::new(&pid_file_path).exists() {
         log::trace!("Reading {} file and checking for running instances.", pid_file_path);


### PR DESCRIPTION
My solution is just to have a function that checks if there is a xdg runtime dir variable and then use if it is exists. If not fallback to /run/user/{uid}. 