### PR TITLE
fix: patch CVE-2022-27814

### DIFF
--- a/src/tests.rs
+++ b/src/tests.rs
@@ -107,7 +107,7 @@ mod test_config {
         assert!(result.is_err());
 
         match result.unwrap_err() {
-            Error::ConfigNotFound => {}
+            Error::ConfigReadError => {}
             _ => {
                 panic!("Error type for nonexistent file is wrong.");
             }


### PR DESCRIPTION
[edit from shinyzenith]

From what I've seen, `std::fs::File::open()` doesn't take into account the UID when trying to detect files. To prevent detection of root-owned files in root directories, I've resorted to using the system `/bin/cat` command for now to open files. It's hacky, but it seems to work.