### PR TITLE
fix: patch CVE-2022-27814 and CVE-2022-27819

### DIFF
--- a/src/daemon.rs
+++ b/src/daemon.rs
@@ -1,9 +1,11 @@
+use crate::config::Value;
 use clap::{arg, Command};
 use evdev::{AttributeSet, Device, InputEventKind, Key};
 use nix::{
     sys::stat::{umask, Mode},
     unistd::{Group, Uid},
 };
+use signal_hook::consts::signal::*;
 use signal_hook_tokio::Signals;
 use std::{
     collections::{HashMap, HashSet},
@@ -22,10 +24,7 @@ use tokio::time::Duration;
 use tokio::time::{sleep, Instant};
 use tokio_stream::{StreamExt, StreamMap};
 
-use signal_hook::consts::signal::*;
-
 mod config;
-use crate::config::Value;
 mod perms;
 mod uinput;
 

--- a/src/daemon.rs
+++ b/src/daemon.rs
@@ -121,8 +121,8 @@ async fn main() -> Result<(), Box<dyn Error>> {
         exit(1);
     }
 
-    let root_resuid = perms::getresuid();
-    let root_resgid = perms::getresgid();
+    let root_resuid = perms::get_resuid();
+    let root_resgid = perms::get_resgid();
 
     let load_config = || {
         // Dropping privileges to invoking user.

--- a/src/daemon.rs
+++ b/src/daemon.rs
@@ -156,9 +156,9 @@ async fn main() -> Result<(), Box<dyn Error>> {
     let mut hotkeys = load_config();
 
     // Escalating back to root after reading config file.
-    perms::setinitgroups(&root_user, root_resuid.real.as_raw());
     perms::setegid(root_resgid.effective.as_raw());
     perms::seteuid(root_resuid.effective.as_raw());
+    perms::setinitgroups(&root_user, root_resuid.real.as_raw());
 
     log::trace!("Attempting to find all keyboard file descriptors.");
     let keyboard_devices: Vec<Device> =

--- a/src/daemon.rs
+++ b/src/daemon.rs
@@ -2,7 +2,7 @@ use clap::{arg, Command};
 use evdev::{AttributeSet, Device, InputEventKind, Key};
 use nix::{
     sys::stat::{umask, Mode},
-    unistd::{Group, Uid},
+    unistd::{Gid, Group, Uid},
 };
 use signal_hook_tokio::Signals;
 use std::{
@@ -446,6 +446,78 @@ pub fn fetch_xdg_runtime_path() -> PathBuf {
             log::error!("XDG_RUNTIME_DIR has not been set.");
             Path::new(&format!("/run/user/{}/swhkd.sock", env::var("PKEXEC_UID").unwrap()))
                 .to_path_buf()
+        }
+    }
+}
+
+pub fn getresuid() -> nix::unistd::ResUid {
+    match nix::unistd::getresuid() {
+        Ok(resuid) => resuid,
+        Err(e) => {
+            log::error!("Failed to get RESUID: {:#?}", e);
+            exit(1);
+        }
+    }
+}
+
+pub fn getresgid() -> nix::unistd::ResGid {
+    match nix::unistd::getresgid() {
+        Ok(resgid) => resgid,
+        Err(e) => {
+            log::error!("Failed to get RESGID: {:#?}", e);
+            exit(1);
+        }
+    }
+}
+
+pub fn setresuid(ruid: u32, euid: u32, suid: u32) {
+    let ruid = Uid::from_raw(ruid);
+    let euid = Uid::from_raw(euid);
+    let suid = Uid::from_raw(suid);
+
+    println!("setresuid: {} {} {}", ruid, euid, suid);
+    match nix::unistd::setresuid(ruid, euid, suid) {
+        Ok(_) => log::debug!("Dropping privileges..."),
+        Err(e) => {
+            log::error!("Failed to set RESUID: {:#?}", e);
+            exit(1);
+        }
+    }
+}
+
+pub fn setresgid(rgid: u32, egid: u32, sgid: u32) {
+    let rgid = Uid::from_raw(rgid);
+    let egid = Uid::from_raw(egid);
+    let sgid = Uid::from_raw(sgid);
+
+    println!("setresgid: {} {} {}", rgid, egid, sgid);
+    match nix::unistd::setresuid(rgid, egid, sgid) {
+        Ok(_) => log::debug!("Dropping privileges..."),
+        Err(e) => {
+            log::error!("Failed to set RESGID: {:#?}", e);
+            exit(1);
+        }
+    }
+}
+
+pub fn setinitgroups(user: &nix::unistd::User, gid: u32) {
+    let gid = Gid::from_raw(gid);
+    match nix::unistd::initgroups(&user.gecos, gid) {
+        Ok(_) => log::debug!("Dropping privileges..."),
+        Err(e) => {
+            log::error!("Failed to set init groups: {:#?}", e);
+            exit(1);
+        }
+    }
+}
+
+pub fn setegid(gid: u32) {
+    let gid = Gid::from_raw(gid);
+    match nix::unistd::setegid(gid) {
+        Ok(_) => log::debug!("Dropping privileges..."),
+        Err(e) => {
+            log::error!("Failed to set EGID: {:#?}", e);
+            exit(1);
         }
     }
 }

--- a/src/daemon.rs
+++ b/src/daemon.rs
@@ -158,7 +158,7 @@ async fn main() -> Result<(), Box<dyn Error>> {
     // Escalating back to root after reading config file.
     perms::setegid(root_resgid.effective.as_raw());
     perms::seteuid(root_resuid.effective.as_raw());
-    perms::setinitgroups(&root_user, root_resuid.real.as_raw());
+    perms::setinitgroups(&root_user, root_resuid.effective.as_raw());
 
     log::trace!("Attempting to find all keyboard file descriptors.");
     let keyboard_devices: Vec<Device> =

--- a/src/daemon.rs
+++ b/src/daemon.rs
@@ -123,15 +123,12 @@ async fn main() -> Result<(), Box<dyn Error>> {
 
     let root_resuid = perms::getresuid();
     let root_resgid = perms::getresgid();
-    let non_root_user = nix::unistd::User::from_uid(Uid::from_raw(invoking_uid)).unwrap().unwrap();
     let root_user =
         nix::unistd::User::from_uid(Uid::from_raw(root_resuid.real.as_raw())).unwrap().unwrap();
 
     let load_config = || {
         // Dropping privileges to invoking user.
-        perms::setinitgroups(&non_root_user, invoking_uid);
-        perms::setegid(invoking_uid);
-        perms::seteuid(invoking_uid);
+        perms::drop_privileges(invoking_uid);
 
         let config_file_path: PathBuf = if args.is_present("config") {
             Path::new(args.value_of("config").unwrap()).to_path_buf()

--- a/src/daemon.rs
+++ b/src/daemon.rs
@@ -2,7 +2,7 @@ use clap::{arg, Command};
 use evdev::{AttributeSet, Device, InputEventKind, Key};
 use nix::{
     sys::stat::{umask, Mode},
-    unistd::{Gid, Group, Uid},
+    unistd::{Group, Uid},
 };
 use signal_hook_tokio::Signals;
 use std::{
@@ -26,6 +26,7 @@ use signal_hook::consts::signal::*;
 
 mod config;
 use crate::config::Value;
+mod perms;
 mod uinput;
 
 #[cfg(test)]
@@ -120,17 +121,17 @@ async fn main() -> Result<(), Box<dyn Error>> {
         exit(1);
     }
 
-    let root_resuid = getresuid();
-    let root_resgid = getresgid();
+    let root_resuid = perms::getresuid();
+    let root_resgid = perms::getresgid();
     let non_root_user = nix::unistd::User::from_uid(Uid::from_raw(invoking_uid)).unwrap().unwrap();
     let root_user =
         nix::unistd::User::from_uid(Uid::from_raw(root_resuid.real.as_raw())).unwrap().unwrap();
 
     let load_config = || {
         // Dropping privileges to invoking user.
-        setinitgroups(&non_root_user, invoking_uid);
-        setegid(invoking_uid);
-        seteuid(invoking_uid);
+        perms::setinitgroups(&non_root_user, invoking_uid);
+        perms::setegid(invoking_uid);
+        perms::seteuid(invoking_uid);
 
         let config_file_path: PathBuf = if args.is_present("config") {
             Path::new(args.value_of("config").unwrap()).to_path_buf()
@@ -158,9 +159,9 @@ async fn main() -> Result<(), Box<dyn Error>> {
     let mut hotkeys = load_config();
 
     // Escalating back to root after reading config file.
-    setinitgroups(&root_user, root_resuid.real.as_raw());
-    setegid(root_resgid.effective.as_raw());
-    seteuid(root_resuid.effective.as_raw());
+    perms::setinitgroups(&root_user, root_resuid.real.as_raw());
+    perms::setegid(root_resgid.effective.as_raw());
+    perms::seteuid(root_resuid.effective.as_raw());
 
     log::trace!("Attempting to find all keyboard file descriptors.");
     let keyboard_devices: Vec<Device> =
@@ -459,89 +460,6 @@ pub fn fetch_xdg_runtime_path() -> PathBuf {
             log::error!("XDG_RUNTIME_DIR has not been set.");
             Path::new(&format!("/run/user/{}/swhkd.sock", env::var("PKEXEC_UID").unwrap()))
                 .to_path_buf()
-        }
-    }
-}
-
-pub fn getresuid() -> nix::unistd::ResUid {
-    match nix::unistd::getresuid() {
-        Ok(resuid) => resuid,
-        Err(e) => {
-            log::error!("Failed to get RESUID: {:#?}", e);
-            exit(1);
-        }
-    }
-}
-
-pub fn getresgid() -> nix::unistd::ResGid {
-    match nix::unistd::getresgid() {
-        Ok(resgid) => resgid,
-        Err(e) => {
-            log::error!("Failed to get RESGID: {:#?}", e);
-            exit(1);
-        }
-    }
-}
-
-pub fn setresuid(ruid: u32, euid: u32, suid: u32) {
-    let ruid = Uid::from_raw(ruid);
-    let euid = Uid::from_raw(euid);
-    let suid = Uid::from_raw(suid);
-
-    println!("setresuid: {} {} {}", ruid, euid, suid);
-    match nix::unistd::setresuid(ruid, euid, suid) {
-        Ok(_) => log::debug!("Dropping privileges..."),
-        Err(e) => {
-            log::error!("Failed to set RESUID: {:#?}", e);
-            exit(1);
-        }
-    }
-}
-
-pub fn setresgid(rgid: u32, egid: u32, sgid: u32) {
-    let rgid = Uid::from_raw(rgid);
-    let egid = Uid::from_raw(egid);
-    let sgid = Uid::from_raw(sgid);
-
-    println!("setresgid: {} {} {}", rgid, egid, sgid);
-    match nix::unistd::setresuid(rgid, egid, sgid) {
-        Ok(_) => log::debug!("Dropping privileges..."),
-        Err(e) => {
-            log::error!("Failed to set RESGID: {:#?}", e);
-            exit(1);
-        }
-    }
-}
-
-pub fn setinitgroups(user: &nix::unistd::User, gid: u32) {
-    let gid = Gid::from_raw(gid);
-    match nix::unistd::initgroups(&user.gecos, gid) {
-        Ok(_) => log::debug!("Dropping privileges..."),
-        Err(e) => {
-            log::error!("Failed to set init groups: {:#?}", e);
-            exit(1);
-        }
-    }
-}
-
-pub fn setegid(gid: u32) {
-    let gid = Gid::from_raw(gid);
-    match nix::unistd::setegid(gid) {
-        Ok(_) => log::debug!("Dropping privileges..."),
-        Err(e) => {
-            log::error!("Failed to set EGID: {:#?}", e);
-            exit(1);
-        }
-    }
-}
-
-pub fn seteuid(uid: u32) {
-    let uid = Uid::from_raw(uid);
-    match nix::unistd::seteuid(uid) {
-        Ok(_) => log::debug!("Dropping privileges..."),
-        Err(e) => {
-            log::error!("Failed to set EUID: {:#?}", e);
-            exit(1);
         }
     }
 }

--- a/src/daemon.rs
+++ b/src/daemon.rs
@@ -125,7 +125,7 @@ async fn main() -> Result<(), Box<dyn Error>> {
     let root_resgid = perms::get_resgid();
 
     let load_config = || {
-        // Dropping privileges to invoking user.
+        // Drop privileges to the invoking user.
         perms::drop_privileges(invoking_uid);
 
         let config_file_path: PathBuf = if args.is_present("config") {
@@ -153,7 +153,7 @@ async fn main() -> Result<(), Box<dyn Error>> {
 
     let mut hotkeys = load_config();
 
-    // Escalating back to root after reading config file.
+    // Escalate back to the root user after reading the config file.
     perms::raise_privileges(root_resgid, root_resuid);
 
     log::trace!("Attempting to find all keyboard file descriptors.");

--- a/src/daemon.rs
+++ b/src/daemon.rs
@@ -123,8 +123,6 @@ async fn main() -> Result<(), Box<dyn Error>> {
 
     let root_resuid = perms::getresuid();
     let root_resgid = perms::getresgid();
-    let root_user =
-        nix::unistd::User::from_uid(Uid::from_raw(root_resuid.real.as_raw())).unwrap().unwrap();
 
     let load_config = || {
         // Dropping privileges to invoking user.
@@ -156,9 +154,7 @@ async fn main() -> Result<(), Box<dyn Error>> {
     let mut hotkeys = load_config();
 
     // Escalating back to root after reading config file.
-    perms::setegid(root_resgid.effective.as_raw());
-    perms::seteuid(root_resuid.effective.as_raw());
-    perms::setinitgroups(&root_user, root_resuid.effective.as_raw());
+    perms::raise_privileges(root_resgid, root_resuid);
 
     log::trace!("Attempting to find all keyboard file descriptors.");
     let keyboard_devices: Vec<Device> =

--- a/src/perms.rs
+++ b/src/perms.rs
@@ -78,7 +78,6 @@ fn set_resuid(ruid: u32, euid: u32, suid: u32) {
     let euid = Uid::from_raw(euid);
     let suid = Uid::from_raw(suid);
 
-    println!("setresuid: {} {} {}", ruid, euid, suid);
     match nix::unistd::setresuid(ruid, euid, suid) {
         Ok(_) => log::debug!("Setting RESUID..."),
         Err(e) => {
@@ -93,7 +92,6 @@ fn set_resgid(rgid: u32, egid: u32, sgid: u32) {
     let egid = Uid::from_raw(egid);
     let sgid = Uid::from_raw(sgid);
 
-    println!("setresgid: {} {} {}", rgid, egid, sgid);
     match nix::unistd::setresuid(rgid, egid, sgid) {
         Ok(_) => log::debug!("Setting RESUID..."),
         Err(e) => {

--- a/src/perms.rs
+++ b/src/perms.rs
@@ -20,6 +20,26 @@ pub fn raise_privileges(resgid: ResGid, resuid: ResUid) {
     setinitgroups(&root_user, resgid);
 }
 
+pub fn getresuid() -> nix::unistd::ResUid {
+    match nix::unistd::getresuid() {
+        Ok(resuid) => resuid,
+        Err(e) => {
+            log::error!("Failed to get RESUID: {:#?}", e);
+            exit(1);
+        }
+    }
+}
+
+pub fn getresgid() -> nix::unistd::ResGid {
+    match nix::unistd::getresgid() {
+        Ok(resgid) => resgid,
+        Err(e) => {
+            log::error!("Failed to get RESGID: {:#?}", e);
+            exit(1);
+        }
+    }
+}
+
 fn setinitgroups(user: &nix::unistd::User, gid: u32) {
     let gid = Gid::from_raw(gid);
     match nix::unistd::initgroups(&user.gecos, gid) {
@@ -48,26 +68,6 @@ fn seteuid(uid: u32) {
         Ok(_) => log::debug!("Dropping privileges..."),
         Err(e) => {
             log::error!("Failed to set EUID: {:#?}", e);
-            exit(1);
-        }
-    }
-}
-
-pub fn getresuid() -> nix::unistd::ResUid {
-    match nix::unistd::getresuid() {
-        Ok(resuid) => resuid,
-        Err(e) => {
-            log::error!("Failed to get RESUID: {:#?}", e);
-            exit(1);
-        }
-    }
-}
-
-pub fn getresgid() -> nix::unistd::ResGid {
-    match nix::unistd::getresgid() {
-        Ok(resgid) => resgid,
-        Err(e) => {
-            log::error!("Failed to get RESGID: {:#?}", e);
             exit(1);
         }
     }

--- a/src/perms.rs
+++ b/src/perms.rs
@@ -43,7 +43,7 @@ pub fn get_resgid() -> nix::unistd::ResGid {
 fn set_initgroups(user: &nix::unistd::User, gid: u32) {
     let gid = Gid::from_raw(gid);
     match nix::unistd::initgroups(&user.gecos, gid) {
-        Ok(_) => log::debug!("Dropping privileges..."),
+        Ok(_) => log::debug!("Setting initgroups..."),
         Err(e) => {
             log::error!("Failed to set init groups: {:#?}", e);
             exit(1);
@@ -54,7 +54,7 @@ fn set_initgroups(user: &nix::unistd::User, gid: u32) {
 fn set_egid(gid: u32) {
     let gid = Gid::from_raw(gid);
     match nix::unistd::setegid(gid) {
-        Ok(_) => log::debug!("Dropping privileges..."),
+        Ok(_) => log::debug!("Setting EGID..."),
         Err(e) => {
             log::error!("Failed to set EGID: {:#?}", e);
             exit(1);
@@ -65,7 +65,7 @@ fn set_egid(gid: u32) {
 fn set_euid(uid: u32) {
     let uid = Uid::from_raw(uid);
     match nix::unistd::seteuid(uid) {
-        Ok(_) => log::debug!("Dropping privileges..."),
+        Ok(_) => log::debug!("Setting EUID..."),
         Err(e) => {
             log::error!("Failed to set EUID: {:#?}", e);
             exit(1);
@@ -80,7 +80,7 @@ fn set_resuid(ruid: u32, euid: u32, suid: u32) {
 
     println!("setresuid: {} {} {}", ruid, euid, suid);
     match nix::unistd::setresuid(ruid, euid, suid) {
-        Ok(_) => log::debug!("Dropping privileges..."),
+        Ok(_) => log::debug!("Setting RESUID..."),
         Err(e) => {
             log::error!("Failed to set RESUID: {:#?}", e);
             exit(1);
@@ -95,7 +95,7 @@ fn set_resgid(rgid: u32, egid: u32, sgid: u32) {
 
     println!("setresgid: {} {} {}", rgid, egid, sgid);
     match nix::unistd::setresuid(rgid, egid, sgid) {
-        Ok(_) => log::debug!("Dropping privileges..."),
+        Ok(_) => log::debug!("Setting RESUID..."),
         Err(e) => {
             log::error!("Failed to set RESGID: {:#?}", e);
             exit(1);

--- a/src/perms.rs
+++ b/src/perms.rs
@@ -1,4 +1,4 @@
-use nix::unistd::{Gid, Uid, User};
+use nix::unistd::{Gid, ResGid, ResUid, Uid, User};
 use std::process::exit;
 
 pub fn drop_privileges(user_uid: u32) {
@@ -8,6 +8,16 @@ pub fn drop_privileges(user_uid: u32) {
     setinitgroups(&user, user_uid.as_raw());
     setegid(user_uid.as_raw());
     seteuid(user_uid.as_raw());
+}
+
+pub fn raise_privileges(resgid: ResGid, resuid: ResUid) {
+    let root_user = User::from_uid(resuid.real).unwrap().unwrap();
+    let resgid = resgid.effective.as_raw();
+    let resuid = resuid.effective.as_raw();
+
+    setegid(resgid);
+    seteuid(resuid);
+    setinitgroups(&root_user, resgid);
 }
 
 pub fn setinitgroups(user: &nix::unistd::User, gid: u32) {

--- a/src/perms.rs
+++ b/src/perms.rs
@@ -20,7 +20,7 @@ pub fn raise_privileges(resgid: ResGid, resuid: ResUid) {
     setinitgroups(&root_user, resgid);
 }
 
-pub fn setinitgroups(user: &nix::unistd::User, gid: u32) {
+fn setinitgroups(user: &nix::unistd::User, gid: u32) {
     let gid = Gid::from_raw(gid);
     match nix::unistd::initgroups(&user.gecos, gid) {
         Ok(_) => log::debug!("Dropping privileges..."),
@@ -31,7 +31,7 @@ pub fn setinitgroups(user: &nix::unistd::User, gid: u32) {
     }
 }
 
-pub fn setegid(gid: u32) {
+fn setegid(gid: u32) {
     let gid = Gid::from_raw(gid);
     match nix::unistd::setegid(gid) {
         Ok(_) => log::debug!("Dropping privileges..."),
@@ -42,7 +42,7 @@ pub fn setegid(gid: u32) {
     }
 }
 
-pub fn seteuid(uid: u32) {
+fn seteuid(uid: u32) {
     let uid = Uid::from_raw(uid);
     match nix::unistd::seteuid(uid) {
         Ok(_) => log::debug!("Dropping privileges..."),
@@ -73,7 +73,7 @@ pub fn getresgid() -> nix::unistd::ResGid {
     }
 }
 
-pub fn setresuid(ruid: u32, euid: u32, suid: u32) {
+fn setresuid(ruid: u32, euid: u32, suid: u32) {
     let ruid = Uid::from_raw(ruid);
     let euid = Uid::from_raw(euid);
     let suid = Uid::from_raw(suid);
@@ -88,7 +88,7 @@ pub fn setresuid(ruid: u32, euid: u32, suid: u32) {
     }
 }
 
-pub fn setresgid(rgid: u32, egid: u32, sgid: u32) {
+fn setresgid(rgid: u32, egid: u32, sgid: u32) {
     let rgid = Uid::from_raw(rgid);
     let egid = Uid::from_raw(egid);
     let sgid = Uid::from_raw(sgid);

--- a/src/perms.rs
+++ b/src/perms.rs
@@ -1,5 +1,14 @@
-use nix::unistd::{Gid, Uid};
+use nix::unistd::{Gid, Uid, User};
 use std::process::exit;
+
+pub fn drop_privileges(user_uid: u32) {
+    let user_uid = Uid::from_raw(user_uid);
+    let user = User::from_uid(user_uid).unwrap().unwrap();
+
+    setinitgroups(&user, user_uid.as_raw());
+    setegid(user_uid.as_raw());
+    seteuid(user_uid.as_raw());
+}
 
 pub fn setinitgroups(user: &nix::unistd::User, gid: u32) {
     let gid = Gid::from_raw(gid);

--- a/src/perms.rs
+++ b/src/perms.rs
@@ -5,9 +5,9 @@ pub fn drop_privileges(user_uid: u32) {
     let user_uid = Uid::from_raw(user_uid);
     let user = User::from_uid(user_uid).unwrap().unwrap();
 
-    setinitgroups(&user, user_uid.as_raw());
-    setegid(user_uid.as_raw());
-    seteuid(user_uid.as_raw());
+    set_initgroups(&user, user_uid.as_raw());
+    set_egid(user_uid.as_raw());
+    set_euid(user_uid.as_raw());
 }
 
 pub fn raise_privileges(resgid: ResGid, resuid: ResUid) {
@@ -15,12 +15,12 @@ pub fn raise_privileges(resgid: ResGid, resuid: ResUid) {
     let resgid = resgid.effective.as_raw();
     let resuid = resuid.effective.as_raw();
 
-    setegid(resgid);
-    seteuid(resuid);
-    setinitgroups(&root_user, resgid);
+    set_egid(resgid);
+    set_euid(resuid);
+    set_initgroups(&root_user, resgid);
 }
 
-pub fn getresuid() -> nix::unistd::ResUid {
+pub fn get_resuid() -> nix::unistd::ResUid {
     match nix::unistd::getresuid() {
         Ok(resuid) => resuid,
         Err(e) => {
@@ -30,7 +30,7 @@ pub fn getresuid() -> nix::unistd::ResUid {
     }
 }
 
-pub fn getresgid() -> nix::unistd::ResGid {
+pub fn get_resgid() -> nix::unistd::ResGid {
     match nix::unistd::getresgid() {
         Ok(resgid) => resgid,
         Err(e) => {
@@ -40,7 +40,7 @@ pub fn getresgid() -> nix::unistd::ResGid {
     }
 }
 
-fn setinitgroups(user: &nix::unistd::User, gid: u32) {
+fn set_initgroups(user: &nix::unistd::User, gid: u32) {
     let gid = Gid::from_raw(gid);
     match nix::unistd::initgroups(&user.gecos, gid) {
         Ok(_) => log::debug!("Dropping privileges..."),
@@ -51,7 +51,7 @@ fn setinitgroups(user: &nix::unistd::User, gid: u32) {
     }
 }
 
-fn setegid(gid: u32) {
+fn set_egid(gid: u32) {
     let gid = Gid::from_raw(gid);
     match nix::unistd::setegid(gid) {
         Ok(_) => log::debug!("Dropping privileges..."),
@@ -62,7 +62,7 @@ fn setegid(gid: u32) {
     }
 }
 
-fn seteuid(uid: u32) {
+fn set_euid(uid: u32) {
     let uid = Uid::from_raw(uid);
     match nix::unistd::seteuid(uid) {
         Ok(_) => log::debug!("Dropping privileges..."),
@@ -73,7 +73,7 @@ fn seteuid(uid: u32) {
     }
 }
 
-fn setresuid(ruid: u32, euid: u32, suid: u32) {
+fn set_resuid(ruid: u32, euid: u32, suid: u32) {
     let ruid = Uid::from_raw(ruid);
     let euid = Uid::from_raw(euid);
     let suid = Uid::from_raw(suid);
@@ -88,7 +88,7 @@ fn setresuid(ruid: u32, euid: u32, suid: u32) {
     }
 }
 
-fn setresgid(rgid: u32, egid: u32, sgid: u32) {
+fn set_resgid(rgid: u32, egid: u32, sgid: u32) {
     let rgid = Uid::from_raw(rgid);
     let egid = Uid::from_raw(egid);
     let sgid = Uid::from_raw(sgid);

--- a/src/perms.rs
+++ b/src/perms.rs
@@ -1,0 +1,85 @@
+use nix::unistd::{Gid, Uid};
+use std::process::exit;
+
+pub fn setinitgroups(user: &nix::unistd::User, gid: u32) {
+    let gid = Gid::from_raw(gid);
+    match nix::unistd::initgroups(&user.gecos, gid) {
+        Ok(_) => log::debug!("Dropping privileges..."),
+        Err(e) => {
+            log::error!("Failed to set init groups: {:#?}", e);
+            exit(1);
+        }
+    }
+}
+
+pub fn setegid(gid: u32) {
+    let gid = Gid::from_raw(gid);
+    match nix::unistd::setegid(gid) {
+        Ok(_) => log::debug!("Dropping privileges..."),
+        Err(e) => {
+            log::error!("Failed to set EGID: {:#?}", e);
+            exit(1);
+        }
+    }
+}
+
+pub fn seteuid(uid: u32) {
+    let uid = Uid::from_raw(uid);
+    match nix::unistd::seteuid(uid) {
+        Ok(_) => log::debug!("Dropping privileges..."),
+        Err(e) => {
+            log::error!("Failed to set EUID: {:#?}", e);
+            exit(1);
+        }
+    }
+}
+
+pub fn getresuid() -> nix::unistd::ResUid {
+    match nix::unistd::getresuid() {
+        Ok(resuid) => resuid,
+        Err(e) => {
+            log::error!("Failed to get RESUID: {:#?}", e);
+            exit(1);
+        }
+    }
+}
+
+pub fn getresgid() -> nix::unistd::ResGid {
+    match nix::unistd::getresgid() {
+        Ok(resgid) => resgid,
+        Err(e) => {
+            log::error!("Failed to get RESGID: {:#?}", e);
+            exit(1);
+        }
+    }
+}
+
+pub fn setresuid(ruid: u32, euid: u32, suid: u32) {
+    let ruid = Uid::from_raw(ruid);
+    let euid = Uid::from_raw(euid);
+    let suid = Uid::from_raw(suid);
+
+    println!("setresuid: {} {} {}", ruid, euid, suid);
+    match nix::unistd::setresuid(ruid, euid, suid) {
+        Ok(_) => log::debug!("Dropping privileges..."),
+        Err(e) => {
+            log::error!("Failed to set RESUID: {:#?}", e);
+            exit(1);
+        }
+    }
+}
+
+pub fn setresgid(rgid: u32, egid: u32, sgid: u32) {
+    let rgid = Uid::from_raw(rgid);
+    let egid = Uid::from_raw(egid);
+    let sgid = Uid::from_raw(sgid);
+
+    println!("setresgid: {} {} {}", rgid, egid, sgid);
+    match nix::unistd::setresuid(rgid, egid, sgid) {
+        Ok(_) => log::debug!("Dropping privileges..."),
+        Err(e) => {
+            log::error!("Failed to set RESGID: {:#?}", e);
+            exit(1);
+        }
+    }
+}

--- a/src/perms.rs
+++ b/src/perms.rs
@@ -72,31 +72,3 @@ fn set_euid(uid: u32) {
         }
     }
 }
-
-fn set_resuid(ruid: u32, euid: u32, suid: u32) {
-    let ruid = Uid::from_raw(ruid);
-    let euid = Uid::from_raw(euid);
-    let suid = Uid::from_raw(suid);
-
-    match nix::unistd::setresuid(ruid, euid, suid) {
-        Ok(_) => log::debug!("Setting RESUID..."),
-        Err(e) => {
-            log::error!("Failed to set RESUID: {:#?}", e);
-            exit(1);
-        }
-    }
-}
-
-fn set_resgid(rgid: u32, egid: u32, sgid: u32) {
-    let rgid = Uid::from_raw(rgid);
-    let egid = Uid::from_raw(egid);
-    let sgid = Uid::from_raw(sgid);
-
-    match nix::unistd::setresuid(rgid, egid, sgid) {
-        Ok(_) => log::debug!("Setting RESUID..."),
-        Err(e) => {
-            log::error!("Failed to set RESGID: {:#?}", e);
-            exit(1);
-        }
-    }
-}


### PR DESCRIPTION
Descriptions of the two CVEs [(source)](https://www.openwall.com/lists/oss-security/2022/04/14/1):

```
2.b) The `-c` Daemon Command Line Parameter Allows for Arbitrary File Existence Tests (CVE-2022-27814)
------------------------------------------------------------------------------------------------------

Example exploitation:

    $ pkexec /usr/bin/swhkd -d -c /root/.somefile
    [2022-03-22T12:32:25Z ERROR swhkd] "/root/.somefile" doesn't exist
    
    $ pkexec /usr/bin/swhkd -d -c /root/.bash_history
    [...] (daemon starts "normal" operation)

2.c) The `-c` Daemon Command Line Parameter Allows to Parse Arbitrary Files (CVE-2022-27819)
--------------------------------------------------------------------------------------------

The file passed to `swhkd` via `-c` will be completely read in by
`swhkd`. Any privileged file can thus also be processed. The daemon only
outputs the contents if something that looks like a hotkey definition is
found in the file, however. Since this syntax is pretty complex the
involved information leak is rather hard to exploit. Something like

    $ pkexec /usr/bin/swhkd -d -c /dev/sda

causes the daemon to "parse" the complete block device, exhausting
memory and causing high I/O load.
```

I've made two functions `drop_privileges` and `raise_privileges` that manipulate the program's `initgroups`, `uid` and `gid`. All three are necessary to modify the program's privileges. Functions relating to permissions are in the new `perms.rs` module.

`daemon.rs` now calls these two functions, so the machine will deny the config parser access to any files/directories the invoking non-root user doesn't have access to.

```rs
pub fn drop_privileges(user_uid: u32) {
    let user_uid = Uid::from_raw(user_uid);
    let user = User::from_uid(user_uid).unwrap().unwrap();

    set_initgroups(&user, user_uid.as_raw());
    set_egid(user_uid.as_raw());
    set_euid(user_uid.as_raw());
}

pub fn raise_privileges(resgid: ResGid, resuid: ResUid) {
    let root_user = User::from_uid(resuid.real).unwrap().unwrap();
    let resgid = resgid.effective.as_raw();
    let resuid = resuid.effective.as_raw();

    set_egid(resgid);
    set_euid(resuid);
    set_initgroups(&root_user, resgid);
}
```