### PR TITLE
[feature] config/daemon: added any modifier

### DIFF
--- a/src/config.rs
+++ b/src/config.rs
@@ -211,6 +211,7 @@ pub enum Modifier {
     Alt,
     Control,
     Shift,
+    Any,
 }
 
 impl Hotkey {
@@ -407,6 +408,7 @@ pub fn parse_contents(path: PathBuf, contents: String) -> Result<Vec<Hotkey>, Er
         ("alt", Modifier::Alt),
         ("mod1", Modifier::Alt),
         ("shift", Modifier::Shift),
+        ("any", Modifier::Any),
     ]);
 
     let lines: Vec<&str> = contents.split('\n').collect();

--- a/src/daemon.rs
+++ b/src/daemon.rs
@@ -261,10 +261,10 @@ async fn main() -> Result<(), Box<dyn Error>> {
 
                 let event_in_hotkeys = hotkeys.iter().any(|hotkey| {
                     hotkey.keysym().code() == event.code() &&
-                    keyboard_state.state_modifiers
+                        (keyboard_state.state_modifiers.len() != 0 && hotkey.modifiers().contains(&config::Modifier::Any) || keyboard_state.state_modifiers
                         .iter()
                         .all(|x| hotkey.modifiers().contains(x)) &&
-                    keyboard_state.state_modifiers.len() == hotkey.modifiers().len()
+                    keyboard_state.state_modifiers.len() == hotkey.modifiers().len())
                     && !hotkey.is_send()
                         });
 
@@ -283,8 +283,8 @@ async fn main() -> Result<(), Box<dyn Error>> {
 
                 for hotkey in possible_hotkeys {
                     // this should check if state_modifiers and hotkey.modifiers have the same elements
-                    if keyboard_state.state_modifiers.iter().all(|x| hotkey.modifiers().contains(x))
-                        && keyboard_state.state_modifiers.len() == hotkey.modifiers().len()
+                    if (keyboard_state.state_modifiers.len() != 0 && hotkey.modifiers().contains(&config::Modifier::Any) || keyboard_state.state_modifiers.iter().all(|x| hotkey.modifiers().contains(x))
+                        && keyboard_state.state_modifiers.len() == hotkey.modifiers().len())
                         && keyboard_state.state_keysyms.contains(hotkey.keysym())
                     {
                         last_hotkey = Some(hotkey.clone());

--- a/src/tests.rs
+++ b/src/tests.rs
@@ -1135,7 +1135,18 @@ super + @~4
             ],
         )
     }
-}
+
+    #[test]
+    fn test_any_modifier() -> std::io::Result<()> {
+        let contents = "
+any + a
+    1";
+        eval_config_test(
+            contents,
+            vec![Hotkey::new(evdev::Key::KEY_A, vec![Modifier::Any], "1".to_string())],
+        )
+    
+}}
 
 mod test_config_display {
     use crate::config::{Error, ParseError};

--- a/src/tests.rs
+++ b/src/tests.rs
@@ -1145,8 +1145,8 @@ any + a
             contents,
             vec![Hotkey::new(evdev::Key::KEY_A, vec![Modifier::Any], "1".to_string())],
         )
-    
-}}
+    }
+}
 
 mod test_config_display {
     use crate::config::{Error, ParseError};


### PR DESCRIPTION
`any` represent any available modifiers.
```
any + a
    1
```
is the same as
```
super + a
    1
ctrl + a
    1
shift + a
    1
alt + a
    1
```
but this is implemented by modifying the daemon part, not expanding the config.