### PR TITLE
fixing a punctuation error in the readme

### DIFF
--- a/README.md
+++ b/README.md
@@ -18,7 +18,7 @@
 
 swhkd is a display protocol-independent hotkey daemon made in Rust. swhkd uses an easy-to-use configuration system inspired by sxhkd so you can easily add or remove hotkeys.
 
-It also attempts to be a drop-in replacement for sxhkd, meaning, your sxhkd config file is also compatible with swhkd.
+It also attempts to be a drop-in replacement for sxhkd, meaning your sxhkd config file is also compatible with swhkd.
 
 Because swhkd can be used anywhere, the same swhkd config can be used across Xorg or Wayland desktops, and you can even use swhkd in a tty.
 


### PR DESCRIPTION
Noticed a punctuation error in the readme, double comma is only used for interrupters or parenthetical elements, which meaning is not in this case.

(sorry if I did anything wrong with this pr, is my first time contributing to a project)