### PR TITLE
non-blocking scdoc check

### DIFF
--- a/swhkd/build.rs
+++ b/swhkd/build.rs
@@ -6,7 +6,7 @@ use std::{
 };
 
 fn main() {
-    if let Err(e) = Command::new("scdoc").spawn() {
+    if let Err(e) = Command::new("scdoc -v").spawn() {
         if let ErrorKind::NotFound = e.kind() {
             exit(0);
         }


### PR DESCRIPTION
Since `scdoc` spawn a blocking process, the build script would hang, using `scdoc -v` doesn't block and works just fine to check if `scdoc` is available.

An alternative could be using the `which` crate: https://crates.io/crates/which

But this fix is "good enough".