### PR TITLE
[fix] raise swhkd privileges right after reading config

### DIFF
--- a/swhkd/src/daemon.rs
+++ b/swhkd/src/daemon.rs
@@ -86,7 +86,11 @@ async fn main() -> Result<(), Box<dyn Error>> {
                 log::error!("Config Error: {}", e);
                 exit(1)
             }
-            Ok(out) => out,
+            Ok(out) => {
+                // Escalate back to the root user after reading the config file.
+                perms::raise_privileges();
+                out
+            }
         }
     };
 
@@ -134,9 +138,6 @@ async fn main() -> Result<(), Box<dyn Error>> {
             }
         };
     }
-
-    // Escalate back to the root user after reading the config file.
-    perms::raise_privileges();
 
     let keyboard_devices: Vec<Device> = {
         if let Some(arg_devices) = args.values_of("device") {


### PR DESCRIPTION
As a fix for CVE-2022-27814, root privileges are dropped to the calling user when (re)loading the config file. Privileges were sometimes dropped but never raised again, which caused crashes when sending SIGHUP to swhkd multiple times in a row.

This now always raises privileges after successfully reading the config file.
Fixes #155.