### PR TITLE
[fix] default `swhks` logpath now references `HOME` environment variable instead of `~`

### DIFF
--- a/docs/swhks.1.scd
+++ b/docs/swhks.1.scd
@@ -19,7 +19,8 @@ swhks - Server for swhkd, used to run user level commands over IPC.
 *-l*, *--log* <LOG_FILE_PATH>
 	Set a log file path.
 	If *XDG_DATA_HOME* exists then we use *swhks/swhks-current_time.log* relative to
-	it, else we use *~/.local/share/swhks/swhks-current_time.log*.
+	it, else we use *.local/share/swhks/swhks-current_time.log* relative to the
+	user home directory.
 
 *-d*, *--debug*
 	Enable debug mode.

--- a/swhks/src/main.rs
+++ b/swhks/src/main.rs
@@ -63,8 +63,15 @@ fn main() -> std::io::Result<()> {
                 "XDG_DATA_HOME Variable is not set, falling back on hardcoded path.\nError: {:#?}",
                 e
             );
-
-                format!("~/.local/share/swhks/swhks-{}.log", time)
+                match env::var("HOME") {
+                    Ok(val) => format!("{}/.local/share/swhks/swhks-{}.log/", val, time),
+                    Err(_) => {
+                        log::error!(
+                            "HOME Variable is not set, cannot fall back on hardcoded path for XDG_DATA_HOME."
+                        );
+                        exit(1);
+                    }
+                }
             }
         }
     };


### PR DESCRIPTION
If `XDG_DATA_HOME` is not set, `swhks` defaults to `~/.local/share/swhks/swhks-{time}.log` for its log files. Unfortunately, `~` is not translated dynamically to the `HOME` user directory path at runtime.

This PR fixes this issue by replacing `~` with a reference to the `HOME` environment variable. If this variable is not set too, the application exits with an error message, as there does not seem to be a way to recover properly in this case.

Closes #157.