### PR TITLE
[fix] release key event shadowed by press event

### DIFF
--- a/swhkd/src/daemon.rs
+++ b/swhkd/src/daemon.rs
@@ -349,7 +349,7 @@ async fn main() -> Result<(), Box<dyn Error>> {
                         }
                         send_command!(hotkey.clone(), &socket_file_path);
                         hotkey_repeat_timer.as_mut().reset(Instant::now() + Duration::from_millis(repeat_cooldown_duration));
-                        break;
+                        continue;
                     }
                 }
             }


### PR DESCRIPTION
swhkd now continues through all "potential" hotkeys so that release hotkeys are still executed, rather than shadowed by a keypress bind.

Fixes #159.