### PR TITLE
[fix] log path being treated as directory

### DIFF
--- a/swhks/src/main.rs
+++ b/swhks/src/main.rs
@@ -64,7 +64,7 @@ fn main() -> std::io::Result<()> {
                 e
             );
                 match env::var("HOME") {
-                    Ok(val) => format!("{}/.local/share/swhks/swhks-{}.log/", val, time),
+                    Ok(val) => format!("{}/.local/share/swhks/swhks-{}.log", val, time),
                     Err(_) => {
                         log::error!(
                             "HOME Variable is not set, cannot fall back on hardcoded path for XDG_DATA_HOME."


### PR DESCRIPTION
There was a `/` left at the end of the log file path in swhks, which causes it to exit upon running a command.