### PR TITLE
Re-emit ignored events from grabbed devices to uinput devices

### DIFF
--- a/swhkd/src/daemon.rs
+++ b/swhkd/src/daemon.rs
@@ -165,7 +165,19 @@ async fn main() -> Result<(), Box<dyn Error>> {
 
     log::debug!("{} Keyboard device(s) detected.", keyboard_devices.len());
 
+    // Apparently, having a single uinput device with keys, relative axes and switches
+    // prevents some libraries to listen to these events. The easy fix is to have separate
+    // virtual devices, one for keys and relative axes (`uinput_device`) and another one
+    // just for switches (`uinput_switches_device`).
     let mut uinput_device = match uinput::create_uinput_device() {
+        Ok(dev) => dev,
+        Err(e) => {
+            log::error!("Err: {:#?}", e);
+            exit(1);
+        }
+    };
+
+    let mut uinput_switches_device = match uinput::create_uinput_switches_device() {
         Ok(dev) => dev,
         Err(e) => {
             log::error!("Err: {:#?}", e);
@@ -270,7 +282,14 @@ async fn main() -> Result<(), Box<dyn Error>> {
 
                 let key = match event.kind() {
                     InputEventKind::Key(keycode) => keycode,
-                    _ => continue
+                    InputEventKind::Switch(_) => {
+                        uinput_switches_device.emit(&[event]).unwrap();
+                        continue
+                    }
+                    _ => {
+                        uinput_device.emit(&[event]).unwrap();
+                        continue
+                    }
                 };
 
                 match event.value() {

--- a/swhkd/src/uinput.rs
+++ b/swhkd/src/uinput.rs
@@ -1,6 +1,6 @@
 use evdev::{
     uinput::{VirtualDevice, VirtualDeviceBuilder},
-    AttributeSet, Key,
+    AttributeSet, Key, RelativeAxisType,
 };
 
 pub fn create_uinput_device() -> Result<VirtualDevice, Box<dyn std::error::Error>> {
@@ -8,14 +8,21 @@ pub fn create_uinput_device() -> Result<VirtualDevice, Box<dyn std::error::Error
     for key in get_all_keys() {
         keys.insert(key);
     }
+
+    let mut relative_axes = AttributeSet::<RelativeAxisType>::new();
+    for axis in get_all_relative_axes() {
+        relative_axes.insert(axis);
+    }
+
     let device = VirtualDeviceBuilder::new()?
         .name("swhkd virtual output")
         .with_keys(&keys)?
+        .with_relative_axes(&relative_axes)?
         .build()
         .unwrap();
     Ok(device)
 }
-pub fn get_all_keys() -> Vec<evdev::Key> {
+pub fn get_all_keys() -> Vec<Key> {
     vec![
         evdev::Key::KEY_RESERVED,
         evdev::Key::KEY_ESC,
@@ -565,5 +572,23 @@ pub fn get_all_keys() -> Vec<evdev::Key> {
         evdev::Key::BTN_TRIGGER_HAPPY38,
         evdev::Key::BTN_TRIGGER_HAPPY39,
         evdev::Key::BTN_TRIGGER_HAPPY40,
+    ]
+}
+
+pub fn get_all_relative_axes() -> Vec<RelativeAxisType> {
+    vec![
+        RelativeAxisType::REL_X,
+        RelativeAxisType::REL_Y,
+        RelativeAxisType::REL_Z,
+        RelativeAxisType::REL_RX,
+        RelativeAxisType::REL_RY,
+        RelativeAxisType::REL_RZ,
+        RelativeAxisType::REL_HWHEEL,
+        RelativeAxisType::REL_DIAL,
+        RelativeAxisType::REL_WHEEL,
+        RelativeAxisType::REL_MISC,
+        RelativeAxisType::REL_RESERVED,
+        RelativeAxisType::REL_WHEEL_HI_RES,
+        RelativeAxisType::REL_HWHEEL_HI_RES,
     ]
 }

--- a/swhkd/src/uinput.rs
+++ b/swhkd/src/uinput.rs
@@ -14,15 +14,23 @@ pub fn create_uinput_device() -> Result<VirtualDevice, Box<dyn std::error::Error
         relative_axes.insert(axis);
     }
 
+    let device = VirtualDeviceBuilder::new()?
+        .name("swhkd virtual output")
+        .with_keys(&keys)?
+        .with_relative_axes(&relative_axes)?
+        .build()
+        .unwrap();
+    Ok(device)
+}
+
+pub fn create_uinput_switches_device() -> Result<VirtualDevice, Box<dyn std::error::Error>> {
     let mut switches = AttributeSet::<SwitchType>::new();
     for switch in get_all_switches() {
         switches.insert(switch);
     }
 
     let device = VirtualDeviceBuilder::new()?
-        .name("swhkd virtual output")
-        .with_keys(&keys)?
-        .with_relative_axes(&relative_axes)?
+        .name("swhkd switches virtual output")
         .with_switches(&switches)?
         .build()
         .unwrap();

--- a/swhkd/src/uinput.rs
+++ b/swhkd/src/uinput.rs
@@ -1,6 +1,6 @@
 use evdev::{
     uinput::{VirtualDevice, VirtualDeviceBuilder},
-    AttributeSet, Key, RelativeAxisType,
+    AttributeSet, Key, RelativeAxisType, SwitchType,
 };
 
 pub fn create_uinput_device() -> Result<VirtualDevice, Box<dyn std::error::Error>> {
@@ -14,10 +14,16 @@ pub fn create_uinput_device() -> Result<VirtualDevice, Box<dyn std::error::Error
         relative_axes.insert(axis);
     }
 
+    let mut switches = AttributeSet::<SwitchType>::new();
+    for switch in get_all_switches() {
+        switches.insert(switch);
+    }
+
     let device = VirtualDeviceBuilder::new()?
         .name("swhkd virtual output")
         .with_keys(&keys)?
         .with_relative_axes(&relative_axes)?
+        .with_switches(&switches)?
         .build()
         .unwrap();
     Ok(device)
@@ -590,5 +596,27 @@ pub fn get_all_relative_axes() -> Vec<RelativeAxisType> {
         RelativeAxisType::REL_RESERVED,
         RelativeAxisType::REL_WHEEL_HI_RES,
         RelativeAxisType::REL_HWHEEL_HI_RES,
+    ]
+}
+
+pub fn get_all_switches() -> Vec<SwitchType> {
+    vec![
+        SwitchType::SW_LID,
+        SwitchType::SW_TABLET_MODE,
+        SwitchType::SW_HEADPHONE_INSERT,
+        SwitchType::SW_RFKILL_ALL,
+        SwitchType::SW_MICROPHONE_INSERT,
+        SwitchType::SW_DOCK,
+        SwitchType::SW_LINEOUT_INSERT,
+        SwitchType::SW_JACK_PHYSICAL_INSERT,
+        SwitchType::SW_VIDEOOUT_INSERT,
+        SwitchType::SW_CAMERA_LENS_COVER,
+        SwitchType::SW_KEYPAD_SLIDE,
+        SwitchType::SW_FRONT_PROXIMITY,
+        SwitchType::SW_ROTATE_LOCK,
+        SwitchType::SW_LINEIN_INSERT,
+        SwitchType::SW_MUTE_DEVICE,
+        SwitchType::SW_PEN_INSERTED,
+        SwitchType::SW_MACHINE_COVER,
     ]
 }


### PR DESCRIPTION
Ignored events (i.e. events other than key presses for now) are re-emitted to the uinput devices. This allows grabbing mouses and other pointer devices while still allowing the cursors to work.

In some cases, events are not re-emitted at all when the uinput device handles keys, relative axes and switches. By sending switch events to a separate uinput device just for switches and another one for keys and relative axes, we can re-emit keys, pointer events, and switches events properly.