### PR TITLE
[fix] Key release events no longer wrongly swallowed by swhkd

### DIFF
--- a/swhkd/src/daemon.rs
+++ b/swhkd/src/daemon.rs
@@ -321,6 +321,8 @@ async fn main() -> Result<(), Box<dyn Error>> {
                         .all(|x| hotkey.modifiers().contains(x)) &&
                     keyboard_state.state_modifiers.len() == hotkey.modifiers().len())
                     && !hotkey.is_send()
+                    && ((hotkey.is_on_release() && event.value() == 0)
+                        || (!hotkey.is_on_release() && event.value() == 1))
                         });
 
                 // Don't emit event to virtual device if it's from a valid hotkey


### PR DESCRIPTION
In some cases, key release events for non-modifier keys are swallowed by swhkd.

Given a simple modifier+key keybinding (ctrl+p for instance): when first pressing a key (p in this example) without a modifier, a key press event is sent to the virtual device to be consumed by other libraries and applications. Pressing the modifier key afterwards triggers the hotkey as expected. Releasing only the key at this point does not send a key release event to the virtual output, as the event_in_hotkeys boolean is true (control is still being pressed and control + p is mapped to a hotkey after all). To any library afterwards, the key is still being pressed as no release event has been received.

To fix this issue, this changes the event_in_hotkey boolean to check for each hotkey if both the event and the hotkey are of the same type. This means that swhkd no longer swallows key press events if a matching hotkey triggers on key release only and it no longer swallows key release events if a matching hotkey triggers on key presses.

Closes #166 