### PR TITLE
[feat] implment mode options

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -193,9 +193,9 @@ dependencies = [
 
 [[package]]
 name = "evdev"
-version = "0.11.7"
+version = "0.12.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c574a78f2156dbd8d6c1bab4bf43f251bffdd84c3b3682ebe82e413fdfec76fe"
+checksum = "e78122445d7c3ce840f1a4f31eb7cee198b9004d03bfc161762d9b4a959d757c"
 dependencies = [
  "bitvec",
  "cfg-if",

--- a/docs/swhkd.5.scd
+++ b/docs/swhkd.5.scd
@@ -93,6 +93,16 @@ q
 	mpc {next, prev, toggle, repeat, random, single}
 endmode # use endmode if you want to set more key bindings for normal mode
 
+# mode options are declared after the mode name
+# swallow: don't emit any event through uinput
+# oneoff: automatically escape a mode when a keybinding defined in it is evoked
+mode option_demo swallow oneoff
+a
+	echo 0
+b
+	@escape # escaping in a 'oneoff' mode pops two modes out of the mode stack.
+endmode
+
 ```
 # AUTHORS
 

--- a/swhkd/src/config.rs
+++ b/swhkd/src/config.rs
@@ -285,7 +285,7 @@ pub struct ModeOptions {
 
 impl ModeOptions {
     pub fn default() -> Self {
-        Self {swallow: false, onceoff: false}
+        Self { swallow: false, onceoff: false }
     }
 }
 

--- a/swhkd/src/config.rs
+++ b/swhkd/src/config.rs
@@ -66,7 +66,7 @@ pub const MODE_END_STATEMENT: &str = "endmode";
 pub const MODE_ENTER_STATEMENT: &str = "@enter";
 pub const MODE_ESCAPE_STATEMENT: &str = "@escape";
 pub const MODE_SWALLOW_STATEMENT: &str = "swallow";
-pub const MODE_ONCEOFF_STATEMENT: &str = "onceoff";
+pub const MODE_ONEOFF_STATEMENT: &str = "oneoff";
 
 #[derive(Debug, PartialEq, Clone, Eq)]
 pub struct Config {
@@ -280,12 +280,12 @@ pub struct Mode {
 #[derive(Debug, Clone, PartialEq)]
 pub struct ModeOptions {
     pub swallow: bool,
-    pub onceoff: bool,
+    pub oneoff: bool,
 }
 
 impl ModeOptions {
     pub fn default() -> Self {
-        Self { swallow: false, onceoff: false }
+        Self { swallow: false, oneoff: false }
     }
 }
 
@@ -559,7 +559,7 @@ pub fn parse_contents(path: PathBuf, contents: String) -> Result<Vec<Mode>, Erro
             let modename = tokens[1];
             let mut mode = Mode::new(modename.to_string());
             mode.options.swallow = tokens.contains(&MODE_SWALLOW_STATEMENT);
-            mode.options.onceoff = tokens.contains(&MODE_ONCEOFF_STATEMENT);
+            mode.options.oneoff = tokens.contains(&MODE_ONEOFF_STATEMENT);
             modes.push(mode);
             current_mode = modes.len() - 1;
         }

--- a/swhkd/src/config.rs
+++ b/swhkd/src/config.rs
@@ -277,16 +277,10 @@ pub struct Mode {
     pub options: ModeOptions,
 }
 
-#[derive(Debug, Clone, PartialEq)]
+#[derive(Debug, Clone, PartialEq, Default)]
 pub struct ModeOptions {
     pub swallow: bool,
     pub oneoff: bool,
-}
-
-impl ModeOptions {
-    pub fn default() -> Self {
-        Self { swallow: false, oneoff: false }
-    }
 }
 
 impl Mode {

--- a/swhkd/src/daemon.rs
+++ b/swhkd/src/daemon.rs
@@ -102,6 +102,9 @@ async fn main() -> Result<(), Box<dyn Error>> {
             log::info!("Hotkey pressed: {:#?}", $hotkey);
             let command = $hotkey.command;
             let mut commands_to_send = String::new();
+            if modes[mode_stack[mode_stack.len()-1]].options.onceoff {
+                mode_stack.pop();
+            }
             if command.contains('@') {
                 let commands = command.split("&&").map(|s| s.trim()).collect::<Vec<_>>();
                 for cmd in commands {
@@ -324,7 +327,7 @@ async fn main() -> Result<(), Box<dyn Error>> {
                         });
 
                 // Don't emit event to virtual device if it's from a valid hotkey
-                if !event_in_hotkeys {
+                if !event_in_hotkeys && !modes[mode_stack[mode_stack.len()-1]].options.swallow {
                     uinput_device.emit(&[event]).unwrap();
                 }
 

--- a/swhkd/src/daemon.rs
+++ b/swhkd/src/daemon.rs
@@ -102,7 +102,7 @@ async fn main() -> Result<(), Box<dyn Error>> {
             log::info!("Hotkey pressed: {:#?}", $hotkey);
             let command = $hotkey.command;
             let mut commands_to_send = String::new();
-            if modes[mode_stack[mode_stack.len()-1]].options.onceoff {
+            if modes[mode_stack[mode_stack.len() - 1]].options.onceoff {
                 mode_stack.pop();
             }
             if command.contains('@') {

--- a/swhkd/src/daemon.rs
+++ b/swhkd/src/daemon.rs
@@ -102,7 +102,7 @@ async fn main() -> Result<(), Box<dyn Error>> {
             log::info!("Hotkey pressed: {:#?}", $hotkey);
             let command = $hotkey.command;
             let mut commands_to_send = String::new();
-            if modes[mode_stack[mode_stack.len() - 1]].options.onceoff {
+            if modes[mode_stack[mode_stack.len() - 1]].options.oneoff {
                 mode_stack.pop();
             }
             if command.contains('@') {

--- a/swhkd/src/daemon.rs
+++ b/swhkd/src/daemon.rs
@@ -326,8 +326,10 @@ async fn main() -> Result<(), Box<dyn Error>> {
                     && !hotkey.is_send()
                         });
 
+                // Only emit event to virtual device when swallow option is off
+                if !modes[mode_stack[mode_stack.len()-1]].options.swallow
                 // Don't emit event to virtual device if it's from a valid hotkey
-                if !event_in_hotkeys && !modes[mode_stack[mode_stack.len()-1]].options.swallow {
+                && !event_in_hotkeys {
                     uinput_device.emit(&[event]).unwrap();
                 }
 


### PR DESCRIPTION
Mode options:

```rust
pub struct Mode {
    pub name: String,
    pub hotkeys: Vec<Hotkey>,
    pub unbinds: Vec<KeyBinding>,
    pub options: ModeOptions,
}

pub struct ModeOptions {
    pub swallow: bool,
    pub onceoff: bool,
}
```
Mode options are declared after the mode name.
Syntax:
`mode modename option1 option2`

Currently, two options are implemented: `swallow` and `onceoff`

`swallow`: Don't emit any event through uinput.
`onceoff`: Automatically escape a mode when a keybinding defined in it is evoked. @BlueDrink9 This may solve #164.

We can add more options by adding members to the `ModeOptions` struct.