### PR TITLE
Strip ~ and @ from modifiers before matching them

### DIFF
--- a/swhkd/src/config.rs
+++ b/swhkd/src/config.rs
@@ -662,7 +662,7 @@ fn parse_keybind(
 
     let modifiers: Vec<Modifier> = tokens_new[0..(tokens_new.len() - 1)]
         .iter()
-        .map(|token| *mod_to_mod_enum.get(token.as_str()).unwrap())
+        .map(|token| *mod_to_mod_enum.get(strip_at(token.as_str())).unwrap())
         .collect();
 
     let mut keybinding = KeyBinding::new(*keysym, modifiers);


### PR DESCRIPTION
Had an issue where a keycombo like `~control + left` was registering as just the left key without modifiers. This makes sure to strip any tildes or at signs before matching the modifier to the table.