### PR TITLE
Use space for rust files in editorconfig

### DIFF
--- a/.editorconfig
+++ b/.editorconfig
@@ -11,5 +11,5 @@ indent_style = tab
 indent_size = 4
 
 [*.rs]
-indent_style = tab
+indent_style = space
 indent_size = 4


### PR DESCRIPTION
This matches what is expected by rustfmt and what is explained in the CONTRIBUTING.md guidelines.