### PR TITLE
Add DESTDIR variable to Makefile

### DIFF
--- a/INSTALL.md
+++ b/INSTALL.md
@@ -4,7 +4,7 @@ We have packaged `swhkd-git`. `swhkd-bin` has been packaged separately by a user
 
 # Building:
 
-`swhkd` and `swhks` install to `/usr/local/bin/` by default. You can change this behaviour by editing the [Makefile](../Makefile) variable, `TARGET_DIR`.
+`swhkd` and `swhks` install to `/usr/local/bin/` by default. You can change this behaviour by editing the [Makefile](../Makefile) variable, `DESTDIR`, which acts as a prefix for all installed files. You can also specify it in the make command line, e.g. to install everything in `subdir`: `make DESTDIR="subdir" install`.
 
 # Dependencies:
 

--- a/Makefile
+++ b/Makefile
@@ -1,3 +1,6 @@
+# Destination dir, defaults to root. Should be overridden for packaging
+# e.g. make DESTDIR="packaging_subdir" install
+DESTDIR ?= "/"
 DAEMON_BINARY := swhkd
 SERVER_BINARY := swhks
 BUILDFLAGS := --release
@@ -17,19 +20,16 @@ build:
 		--swhkd-path=$(TARGET_DIR)/$(DAEMON_BINARY)
 
 install:
-	@mkdir -p $(MAN1_DIR)
-	@mkdir -p $(MAN5_DIR)
-	@mkdir -p $(POLKIT_DIR)
-	@mkdir -p $(TARGET_DIR)
-	@mkdir -p /etc/$(DAEMON_BINARY)
-	@find ./docs -type f -iname "*.1.gz" -exec cp {} $(MAN1_DIR) \;
-	@find ./docs -type f -iname "*.5.gz" -exec cp {} $(MAN5_DIR) \;
-	@touch /etc/$(DAEMON_BINARY)/$(DAEMON_BINARY)rc
-	@cp ./target/release/$(DAEMON_BINARY) $(TARGET_DIR)
-	@cp ./target/release/$(SERVER_BINARY) $(TARGET_DIR)
-	@cp ./$(POLKIT_POLICY_FILE) $(POLKIT_DIR)/$(POLKIT_POLICY_FILE)
-	@chmod +x $(TARGET_DIR)/$(DAEMON_BINARY)
-	@chmod +x $(TARGET_DIR)/$(SERVER_BINARY)
+	@find ./docs -type f -iname "*.1.gz" \
+		-exec install -Dm 644 {} -t $(DESTDIR)/$(MAN1_DIR) \;
+	@find ./docs -type f -iname "*.5.gz" \
+		-exec install -Dm 644 {} -t $(DESTDIR)/$(MAN1_DIR) \;
+	@install -Dm 755 ./target/release/$(DAEMON_BINARY) -t $(DESTDIR)/$(TARGET_DIR)
+	@install -Dm 755 ./target/release/$(SERVER_BINARY) -t $(DESTDIR)/$(TARGET_DIR)
+	@install -Dm 644 -o root ./$(POLKIT_POLICY_FILE) -t $(DESTDIR)/$(POLKIT_DIR)
+# Ideally, we would have a default config file instead of an empty one
+	@touch ./$(DAEMON_BINARY)rc
+	@install -Dm 644 ./$(DAEMON_BINARY) -t $(DESTDIR)/etc/$(DAEMON_BINARY)
 
 uninstall:
 	@$(RM) -f /usr/share/man/**/swhkd.*

--- a/contrib/PKGBUILD
+++ b/contrib/PKGBUILD
@@ -26,13 +26,7 @@ build(){
 
 package() {
 	cd "$_pkgname"
-	install -Dm 755 ./target/release/swhkd "$pkgdir/usr/bin/swhkd"
-	install -Dm 755 ./target/release/swhks "$pkgdir/usr/bin/swhks"
-
-	install -Dm 644 -o root ./com.github.swhkd.pkexec.policy -t "$pkgdir/usr/share/polkit-1/actions"
-
-	install -Dm 644 ./docs/*.1.gz -t "$pkgdir/usr/share/man/man1/"
-	install -Dm 644 ./docs/*.5.gz -t "$pkgdir/usr/share/man/man5/"
+	make DESTDIR="$pkgdir/" install
 
     cd "${srcdir}/${_pkgname}-vim"
     for i in ftdetect ftplugin indent syntax; do


### PR DESCRIPTION
This PR depends on #184 which must be merged before this one.

This adds a `DESTDIR` variable to the `Makefile` which acts as a prefix for all directories in the `install` make target. This will make it much easier to package swhkd, as now building and installing boils down to: `make && make DESTDIR="packaging_subdir" install`. The default is still to install to the root.

This PR also updates `contrib/PKGBUILD` to make use of this updated `install` make target.