### PR TITLE
Add first version of changelog file

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,0 +1,28 @@
+# Changelog
+
+All notable changes to this project will be documented in this file.
+
+The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
+and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
+
+## Unreleased
+
+### Added
+
+- New configuration options for modes. These options apply to all keybindings in a mode.
+- `swallow` mode option: all keybindings associated with this mode do not emit events
+- `oneoff` mode option: automatically exits a mode after using a keybind
+- `DESTDIR` variable for the `install` target in the `Makefile` to help
+  packaging and installation. To install in a subdirectory, just call `make
+  DESTDIR=subdir install`.
+
+### Changed
+
+- The project `Makefile` now builds the polkit policy file dynamically depending
+  on the target installation directories.
+
+### Fixed
+
+- Mouse cursors and other devices are no longer blocked when running `swhkd`.
+- Option prefixes on modifiers are now properly parsed. e.g., `~control` is now
+  understood by `swhkd` as the `control` modifier with an option


### PR DESCRIPTION
This changelog is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/) as discussed in #181.

For now, it only contains unreleased changes. These changes are tracked based on where the future 1.2.2 version will be. I decided to include build system changes in there, just because it might be important/useful for package maintainers.

Contributors are not listed in this version of the changelog directly to keep it lean. This is debatable, but I think contributors should be listed (and thanked!) in the GitHub releases instead. Feel free to open an issue to discuss this further if needed.

I am open to suggestion for changes to the current text, the format, or anything else.