### PR TITLE
Install man docs to correct location

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -20,6 +20,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 - The project `Makefile` now builds the polkit policy file dynamically depending
   on the target installation directories.
+  
+### Fixed
+
+- Install mandocs in the correct locations.
 
 ### Fixed
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -20,13 +20,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 - The project `Makefile` now builds the polkit policy file dynamically depending
   on the target installation directories.
-  
-### Fixed
-
-- Install mandocs in the correct locations.
 
 ### Fixed
 
 - Mouse cursors and other devices are no longer blocked when running `swhkd`.
 - Option prefixes on modifiers are now properly parsed. e.g., `~control` is now
   understood by `swhkd` as the `control` modifier with an option
+- Install mandocs in the correct locations.

--- a/Makefile
+++ b/Makefile
@@ -23,7 +23,7 @@ install:
 	@find ./docs -type f -iname "*.1.gz" \
 		-exec install -Dm 644 {} -t $(DESTDIR)/$(MAN1_DIR) \;
 	@find ./docs -type f -iname "*.5.gz" \
-		-exec install -Dm 644 {} -t $(DESTDIR)/$(MAN1_DIR) \;
+		-exec install -Dm 644 {} -t $(DESTDIR)/$(MAN5_DIR) \;
 	@install -Dm 755 ./target/release/$(DAEMON_BINARY) -t $(DESTDIR)/$(TARGET_DIR)
 	@install -Dm 755 ./target/release/$(SERVER_BINARY) -t $(DESTDIR)/$(TARGET_DIR)
 	@install -Dm 644 -o root ./$(POLKIT_POLICY_FILE) -t $(DESTDIR)/$(POLKIT_DIR)


### PR DESCRIPTION
This is a simple typo fix to man5 docs being installed in the man1 location.