### PR TITLE
Implement altgr modifier

### DIFF
--- a/docs/swhkd-keys.5.scd
+++ b/docs/swhkd-keys.5.scd
@@ -12,6 +12,8 @@ swhkd	- Hotkey daemon inspired by sxhkd written in rust
 	- Mod4
 	- Alt
 	- Mod1
+	- Altgr
+	- Mod5
 	- Shift
 
 # VALID KEYS

--- a/swhkd/src/config.rs
+++ b/swhkd/src/config.rs
@@ -228,6 +228,7 @@ pub struct Hotkey {
 pub enum Modifier {
     Super,
     Alt,
+    Altgr,
     Control,
     Shift,
     Any,
@@ -452,6 +453,8 @@ pub fn parse_contents(path: PathBuf, contents: String) -> Result<Vec<Mode>, Erro
         ("mod4", Modifier::Super),
         ("alt", Modifier::Alt),
         ("mod1", Modifier::Alt),
+        ("altrg", Modifier::Altgr),
+        ("mod5", Modifier::Altgr),
         ("shift", Modifier::Shift),
         ("any", Modifier::Any),
     ]);

--- a/swhkd/src/config.rs
+++ b/swhkd/src/config.rs
@@ -453,7 +453,7 @@ pub fn parse_contents(path: PathBuf, contents: String) -> Result<Vec<Mode>, Erro
         ("mod4", Modifier::Super),
         ("alt", Modifier::Alt),
         ("mod1", Modifier::Alt),
-        ("altrg", Modifier::Altgr),
+        ("altgr", Modifier::Altgr),
         ("mod5", Modifier::Altgr),
         ("shift", Modifier::Shift),
         ("any", Modifier::Any),

--- a/swhkd/src/daemon.rs
+++ b/swhkd/src/daemon.rs
@@ -193,7 +193,7 @@ async fn main() -> Result<(), Box<dyn Error>> {
         (Key::KEY_LEFTMETA, config::Modifier::Super),
         (Key::KEY_RIGHTMETA, config::Modifier::Super),
         (Key::KEY_LEFTALT, config::Modifier::Alt),
-        (Key::KEY_RIGHTALT, config::Modifier::Alt),
+        (Key::KEY_RIGHTALT, config::Modifier::Altgr),
         (Key::KEY_LEFTCTRL, config::Modifier::Control),
         (Key::KEY_RIGHTCTRL, config::Modifier::Control),
         (Key::KEY_LEFTSHIFT, config::Modifier::Shift),

--- a/swhkd/src/tests.rs
+++ b/swhkd/src/tests.rs
@@ -398,6 +398,9 @@ control + 5
 alt + 2
     notify-send 'Hello world!'
 
+altgr + i
+    notify-send 'Hello world!'
+
 super + z
     notify-send 'Hello world!'
             ";
@@ -416,6 +419,11 @@ super + z
             Hotkey::new(
                 evdev::Key::KEY_2,
                 vec![Modifier::Alt],
+                "notify-send 'Hello world!'".to_string(),
+            ),
+            Hotkey::new(
+                evdev::Key::KEY_I,
+                vec![Modifier::Altgr],
                 "notify-send 'Hello world!'".to_string(),
             ),
             Hotkey::new(


### PR DESCRIPTION
Changes the behavior of the right alt key. Now the right alt key will be it's own independent modifier key. 
The right alt key is usually called the "alt graph" or "alt gr" keys on non-us English keyboards. 

The alt gr key usually allows for typing foreign symbols, accented letters, äßöü, etc. However since swhkd treats the right alt the same as the left alt, there was no way to type these characters.

The changes made allow for users to keep using the left alt key to work as normal, but give the choice to users to utilise another "layer" of characters, or another "layer" of hotkeys. Hence, it does not remove any functionality, and not break any configuration files.

https://en.wikipedia.org/w/index.php?title=QWERTY&lang=en#United_States
https://en.wikipedia.org/wiki/Alt_key?lang=en
https://en.wikipedia.org/w/index.php?title=AltGr_key&lang=en 