### PR TITLE
[feat] Add `leftsuper` and `rightsuper` Keys

### DIFF
--- a/docs/swhkd-keys.5.scd
+++ b/docs/swhkd-keys.5.scd
@@ -59,6 +59,8 @@ swhkd	- Hotkey daemon inspired by sxhkd written in rust
 	- tab
 	- space
 	- plus
+	- leftsuper
+	- rightsuper
 	- kp0
 	- kp1
 	- kp2

--- a/swhkd/src/config.rs
+++ b/swhkd/src/config.rs
@@ -340,6 +340,8 @@ pub fn parse_contents(path: PathBuf, contents: String) -> Result<Vec<Mode>, Erro
         ("tab", evdev::Key::KEY_TAB),
         ("space", evdev::Key::KEY_SPACE),
         ("plus", evdev::Key::KEY_KPPLUS), // Shouldn't this be kpplus?
+        ("leftsuper", evdev::Key::KEY_LEFTMETA),
+        ("rightsuper", evdev::Key::KEY_RIGHTMETA),
         ("kp0", evdev::Key::KEY_KP0),
         ("kp1", evdev::Key::KEY_KP1),
         ("kp2", evdev::Key::KEY_KP2),

--- a/swhkd/src/tests.rs
+++ b/swhkd/src/tests.rs
@@ -301,13 +301,21 @@ w
 
 t
     /bin/firefox
+
+leftsuper
+    konsole
+
+rightsuper
+    qutebrowser
         ";
 
         let hotkey_1 = Hotkey::new(evdev::Key::KEY_R, vec![], String::from("alacritty"));
         let hotkey_2 = Hotkey::new(evdev::Key::KEY_W, vec![], String::from("kitty"));
         let hotkey_3 = Hotkey::new(evdev::Key::KEY_T, vec![], String::from("/bin/firefox"));
+        let hotkey_4 = Hotkey::new(evdev::Key::KEY_LEFTMETA, vec![], String::from("konsole"));
+        let hotkey_5 = Hotkey::new(evdev::Key::KEY_RIGHTMETA, vec![], String::from("qutebrowser"));
 
-        eval_config_test(contents, vec![hotkey_1, hotkey_2, hotkey_3])
+        eval_config_test(contents, vec![hotkey_1, hotkey_2, hotkey_3, hotkey_4, hotkey_5])
     }
 
     #[test]


### PR DESCRIPTION
# Motivation

Towards a more [ergonomic working environment](https://en.wikipedia.org/wiki/Sticky_keys). [This PR enables the use of the `super` key as a keysym.](https://github.com/waycrate/swhkd/issues/209)

# Help Needed

All tests successfully pass:

```txt
$ make test
test result: ok. 51 passed; 0 failed; 0 ignored; 0 measured; 0 filtered out; finished in 0.04s

     Running unittests src/main.rs (target/debug/deps/swhks-328709fb84de0909)

running 0 tests

test result: ok. 0 passed; 0 failed; 0 ignored; 0 measured; 0 filtered out; finished in 0.00s
```

However, the added unit test does not seem to work as expected when added to `$HOME/.config/swhkd/swhkdrc`:

```txt
leftsuper
    konsole

rightsuper
    qutebrowser
```

Possibly, the key listener is unable to distinguish between `config::Modifier::Super` and `Key::KEY_LEFTMETA` or `Key::KEY_RIGHTMETA` key presses because [both `Key::KEY_LEFTMETA` and `Key::KEY_RIGHTMETA` keys are mapped to the same `config::Modifier::Super` modifier](https://github.com/waycrate/swhkd/blob/8377aaf92a3516c1e12741b0436346989681e0b6/swhkd/src/daemon.rs#L192%23L201):

```rust
let modifiers_map: HashMap<Key, config::Modifier> = HashMap::from([
    (Key::KEY_LEFTMETA, config::Modifier::Super),
    (Key::KEY_RIGHTMETA, config::Modifier::Super),
]);
```

Since I am unfamiliar with Rust, I believe it would be appropriate for someone with Rust experience to handle this situation.

# Closes Issue

- https://github.com/waycrate/swhkd/issues/209

# Related Issues

- https://github.com/waycrate/swhkd/issues/103
- https://github.com/waycrate/swhkd/issues/211

# Heavily Inspired By

- https://github.com/waycrate/swhkd/pull/213