### PR TITLE
feat: added @pend internal command

### DIFF
--- a/swhkd/src/config.rs
+++ b/swhkd/src/config.rs
@@ -65,6 +65,7 @@ pub const MODE_STATEMENT: &str = "mode";
 pub const MODE_END_STATEMENT: &str = "endmode";
 pub const MODE_ENTER_STATEMENT: &str = "@enter";
 pub const MODE_ESCAPE_STATEMENT: &str = "@escape";
+pub const MODE_PEND_STATEMENT: &str = "@pend";
 pub const MODE_SWALLOW_STATEMENT: &str = "swallow";
 pub const MODE_ONEOFF_STATEMENT: &str = "oneoff";
 


### PR DESCRIPTION
This could fix #219 @tsankuanglee

## Usage

Use `@pend mode_name` to enter a mode, and the remaining commands will not run until the mode is escaped with `@escape` or `oneoff`.

## Example

swhkdrc:
```
super + r
  notify-send "entering resize mode" && @pend resize && notify-send "exiting resize mode"

mode resize
{h, l, j, k}
  hyprctl dispatch resizeactive {\-5 0, 5 0, 0 5, 0 \-5}
ctrl + c
  notify-send "entering move-canvas mode" && @pend move-canvas && notify-send "exiting move-canvas mode"
q
  @escape
endmode

mode move-canvas
{h, l, j, k}
  /home/eden/.config/hypr/scripts/move-canvas {5 0, \-5 0, 0 \-5, 0 5}
q
  @escape
endmode
```
When `super + r` is pressed, the notification "entering resize mode" would show up, and we will enter resize mode.

In resize mode, when `ctrl + c` is pressed, notification "entering move-canvas mode" would show up, and we will enter the move-canvas mode.

After that, when `q` is pressed, we will escape from move-canvas mode, and notification "leaving move-canvas mode" would show up. Now we are still in resize mode.

Finally, when `q` is pressed, we will escape from resize mode and notification "exiting resize mode" would show up.