### PR TITLE
Add libudev compile requirement to INSTALL.md

### DIFF
--- a/INSTALL.md
+++ b/INSTALL.md
@@ -19,6 +19,7 @@ We have packaged `swhkd-git`. `swhkd-bin` has been packaged separately by a user
 -   git
 -   scdoc (If present, man-pages will be generated)
 -   make
+-   libudev (in Debian, the package name is `libudev-dev`)
 -   rustup
 
 # Compiling:


### PR DESCRIPTION
This is my first time comping this repo (with Rust official docker image). I had to add `libudev-dev` to compile. Adding that to the doc.