### PR TITLE
docs(readme): fix typo in systemd readme

### DIFF
--- a/contrib/init/systemd/README.md
+++ b/contrib/init/systemd/README.md
@@ -4,6 +4,6 @@ To have systemd automatically start `swhkd` for you:
 
 1. Copy `hotkeys.sh` into your preferred directory
 2. `chmod +x hotkeys.sh`
-3. Copy `hotkeys.service` into your `$XDG_CONFIG_DIR/systemd/user` directory
+3. Copy `hotkeys.service` into your `$XDG_CONFIG_DIRS/systemd/user` directory
 4. Using a text editor, uncomment line 7 of `hotkeys.service` and change the path accordingly
 5. In a terminal: `systemctl --user enable hotkeys.service`


### PR DESCRIPTION
$XDG_CONFIG_DIR does not seem to be part of the XDG Base Directory Specification, systemd/user is in $XDG_CONFIG_DIRS

Changed to $XDG_CONFIG_DIRS