### PR TITLE
[fix] don't override global RUST_LOG variable

### DIFF
--- a/swhks/src/main.rs
+++ b/swhks/src/main.rs
@@ -16,8 +16,6 @@ use std::{
 use sysinfo::{ProcessExt, System, SystemExt};
 
 fn main() -> std::io::Result<()> {
-    env::set_var("RUST_LOG", "swhks=warn");
-
     let app = clap::Command::new("swhks")
         .version(env!("CARGO_PKG_VERSION"))
         .author(env!("CARGO_PKG_AUTHORS"))
@@ -30,10 +28,12 @@ fn main() -> std::io::Result<()> {
 		));
     let args = app.get_matches();
     if args.is_present("debug") {
-        env::set_var("RUST_LOG", "swhks=trace");
+        env_logger::Builder::from_env(env_logger::Env::default().default_filter_or("swhks=trace"))
+            .init();
+    } else {
+        env_logger::Builder::from_env(env_logger::Env::default().default_filter_or("swhks=warn"))
+            .init();
     }
-
-    env_logger::init();
 
     log::trace!("Setting process umask.");
     umask(Mode::S_IWGRP | Mode::S_IWOTH);


### PR DESCRIPTION
Overriding the RUST_LOG variable means it propagates to rust programs spawned by swhks, directly and indirectly.

implementation inspired by the example in the [env_logger](https://docs.rs/env_logger/latest/env_logger/#specifying-defaults-for-environment-variables) docs.