### PR TITLE
refactor: remove manual implementation of `fs::read_to_string`

### DIFF
--- a/swhkd/src/config.rs
+++ b/swhkd/src/config.rs
@@ -1,7 +1,6 @@
 use itertools::Itertools;
 use std::collections::HashMap;
-use std::fs::File;
-use std::io::Read;
+use std::fs;
 use std::{
     fmt,
     path::{Path, PathBuf},
@@ -75,13 +74,6 @@ pub struct Config {
     pub imports: Vec<PathBuf>,
 }
 
-pub fn load_file_contents(path: &Path) -> Result<String, Error> {
-    let mut file = File::open(path)?;
-    let mut contents = String::new();
-    file.read_to_string(&mut contents)?;
-    Ok(contents)
-}
-
 impl Config {
     pub fn get_imports(contents: &str) -> Result<Vec<PathBuf>, Error> {
         let mut imports = Vec::new();
@@ -96,7 +88,7 @@ impl Config {
     }
 
     pub fn new(path: &Path) -> Result<Self, Error> {
-        let contents = load_file_contents(path)?;
+        let contents = fs::read_to_string(path)?;
         let imports = Self::get_imports(&contents)?;
         Ok(Config { path: path.to_path_buf(), contents, imports })
     }

--- a/swhkd/src/tests.rs
+++ b/swhkd/src/tests.rs
@@ -1,7 +1,6 @@
 mod test_config {
     use crate::config::{
-        extract_curly_brace, load, load_file_contents, parse_contents, Error, Hotkey, Modifier,
-        ParseError, Prefix,
+        extract_curly_brace, load, parse_contents, Error, Hotkey, Modifier, ParseError, Prefix,
     };
     use std::fs;
     use std::io::Write;
@@ -100,22 +99,6 @@ mod test_config {
     }
 
     #[test]
-    fn test_nonexistent_file() {
-        let path = PathBuf::from(r"This File Doesn't Exist");
-
-        let result = load_file_contents(&path);
-
-        assert!(result.is_err());
-
-        match result.unwrap_err() {
-            Error::ConfigNotFound => {}
-            _ => {
-                panic!("Error type for nonexistent file is wrong.");
-            }
-        }
-    }
-
-    #[test]
     fn test_existing_file() -> std::io::Result<()> {
         let setup = TestPath::new("/tmp/swhkd-test-file1");
         // Build a dummy file in /tmp
@@ -129,7 +112,7 @@ q
     bspc node -q",
         )?;
 
-        let result = load_file_contents(&setup.path());
+        let result = fs::read_to_string(&setup.path());
         assert!(result.is_ok());
         Ok(())
     }


### PR DESCRIPTION
### Changes
- Removed `load_file_contents` which is a manual implementation of `fs::read_to_string`.
- Replaced respective occurrences in `Config::new` and tests. 