### PR TITLE
[fix] better keyboard checking

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -4,4 +4,5 @@ target
 *.out
 com.github.swhkd.pkexec.policy
 *rc
+!*rc/
 .direnv

--- a/swhkd/src/daemon.rs
+++ b/swhkd/src/daemon.rs
@@ -1,6 +1,6 @@
 use crate::config::Value;
 use clap::{arg, Command};
-use evdev::{AttributeSet, Device, InputEventKind, Key};
+use evdev::{AttributeSet, Device, EventType as EvType, InputEventKind, Key};
 use nix::{
     sys::stat::{umask, Mode},
     unistd::{Group, Uid},
@@ -459,10 +459,10 @@ pub fn check_input_group() -> Result<(), Box<dyn Error>> {
 }
 
 pub fn check_device_is_keyboard(device: &Device) -> bool {
-    if device.supported_keys().map_or(false, |keys| keys.contains(Key::KEY_ENTER)) {
-        if device.name() == Some("swhkd virtual output") {
-            return false;
-        }
+    let events = device.supported_events();
+    if device.name() == Some("swhkd virtual output") {
+        false
+    } else if events.contains(EvType::KEY) && events.contains(EvType::REPEAT) {
         log::debug!("Keyboard: {}", device.name().unwrap(),);
         true
     } else {


### PR DESCRIPTION
Inspired from <https://unix.stackexchange.com/questions/523108/getting-type-of-evdev-device>. My mouse was incorrectly getting recognized as a keyboard because of [this](https://docs.rs/evdev/latest/evdev/struct.Device.html#method.supported_keys). I tried this on my laptop keyboard and with a couple of keyboards I had lying around, and this seems to be consistent. 

**NOTE**: this needs to be tested across devices and setups

- All keyboards seem to have EV_KEY and EV_REP
- *rc pattern was ignoring all src/ directories