### PR TITLE
[refactor] environment variable initialization

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -3,5 +3,5 @@ target
 *.gz
 *.out
 com.github.swhkd.pkexec.policy
-*rc
+# *rc
 .direnv

--- a/.gitignore
+++ b/.gitignore
@@ -3,5 +3,6 @@ target
 *.gz
 *.out
 com.github.swhkd.pkexec.policy
-# *rc
+*rc
+!*rc/
 .direnv

--- a/swhks/src/environ.rs
+++ b/swhks/src/environ.rs
@@ -1,7 +1,7 @@
 //! Environ.rs
 //! Defines modules and structs for handling environment variables and paths.
 
-use std::{path::PathBuf, env::VarError};
+use std::{env::VarError, path::PathBuf};
 
 use nix::unistd;
 
@@ -39,9 +39,11 @@ impl Env {
             Ok(val) => val,
             Err(e) => match e {
                 EnvError::DataHomeNotSet => {
-                    log::warn!("XDG_DATA_HOME Variable is not set, falling back on hardcoded path.");
+                    log::warn!(
+                        "XDG_DATA_HOME Variable is not set, falling back on hardcoded path."
+                    );
                     home.join(".local/share")
-                },
+                }
                 _ => panic!("Unexpected error: {:#?}", e),
             },
         };
@@ -50,18 +52,16 @@ impl Env {
             Ok(val) => val,
             Err(e) => match e {
                 EnvError::RuntimeDirNotSet => {
-                    log::warn!("XDG_RUNTIME_DIR Variable is not set, falling back on hardcoded path.");
+                    log::warn!(
+                        "XDG_RUNTIME_DIR Variable is not set, falling back on hardcoded path."
+                    );
                     PathBuf::from(format!("/run/user/{}", unistd::Uid::current()))
-                },
+                }
                 _ => panic!("Unexpected error: {:#?}", e),
             },
         };
 
-        Self {
-            data_home,
-            home,
-            runtime_dir,
-        }
+        Self { data_home, home, runtime_dir }
     }
 
     /// Actual interface to get the environment variable.

--- a/swhks/src/environ.rs
+++ b/swhks/src/environ.rs
@@ -1,0 +1,84 @@
+//! Environ.rs
+//! Defines modules and structs for handling environment variables and paths.
+
+use std::{path::PathBuf, env::VarError};
+
+use nix::unistd;
+
+// The main struct for handling environment variables.
+// Contains the values of the environment variables in the form of PathBuffers.
+pub struct Env {
+    pub data_home: PathBuf,
+    pub home: PathBuf,
+    pub runtime_dir: PathBuf,
+}
+
+/// Error type for the Env struct.
+/// Contains all the possible errors that can occur when trying to get an environment variable.
+#[derive(Debug)]
+pub enum EnvError {
+    DataHomeNotSet,
+    HomeNotSet,
+    RuntimeDirNotSet,
+    GenericError(String),
+}
+
+impl Env {
+    /// Constructs a new Env struct.
+    /// This function is called only once and the result is stored in a static variable.
+    pub fn construct() -> Self {
+        let home = match Self::get_env("HOME") {
+            Ok(val) => val,
+            Err(_) => {
+                eprintln!("HOME Variable is not set, cannot fall back on hardcoded path for XDG_DATA_HOME.");
+                std::process::exit(1);
+            }
+        };
+
+        let data_home = match Self::get_env("XDG_DATA_HOME") {
+            Ok(val) => val,
+            Err(e) => match e {
+                EnvError::DataHomeNotSet => {
+                    log::warn!("XDG_DATA_HOME Variable is not set, falling back on hardcoded path.");
+                    home.join(".local/share")
+                },
+                _ => panic!("Unexpected error: {:#?}", e),
+            },
+        };
+
+        let runtime_dir = match Self::get_env("XDG_RUNTIME_DIR") {
+            Ok(val) => val,
+            Err(e) => match e {
+                EnvError::RuntimeDirNotSet => {
+                    log::warn!("XDG_RUNTIME_DIR Variable is not set, falling back on hardcoded path.");
+                    PathBuf::from(format!("/run/user/{}", unistd::Uid::current()))
+                },
+                _ => panic!("Unexpected error: {:#?}", e),
+            },
+        };
+
+        Self {
+            data_home,
+            home,
+            runtime_dir,
+        }
+    }
+
+    /// Actual interface to get the environment variable.
+    fn get_env(name: &str) -> Result<PathBuf, EnvError> {
+        match std::env::var(name) {
+            Ok(val) => Ok(PathBuf::from(val)),
+            Err(e) => match e {
+                VarError::NotPresent => match name {
+                    "XDG_DATA_HOME" => Err(EnvError::DataHomeNotSet),
+                    "HOME" => Err(EnvError::HomeNotSet),
+                    "XDG_RUNTIME_DIR" => Err(EnvError::RuntimeDirNotSet),
+                    _ => Err(EnvError::GenericError(format!("{} not set", name))),
+                },
+                VarError::NotUnicode(_) => {
+                    Err(EnvError::GenericError(format!("{} not unicode", name)))
+                }
+            },
+        }
+    }
+}

--- a/swhks/src/main.rs
+++ b/swhks/src/main.rs
@@ -11,7 +11,8 @@ use std::{
     os::unix::net::UnixListener,
     path::Path,
     process::{exit, id, Command, Stdio},
-    time::{SystemTime, UNIX_EPOCH}, sync::OnceLock,
+    sync::OnceLock,
+    time::{SystemTime, UNIX_EPOCH},
 };
 use sysinfo::{ProcessExt, System, SystemExt};
 

--- a/swhks/src/main.rs
+++ b/swhks/src/main.rs
@@ -1,10 +1,11 @@
-use std::io::Read;
 use clap::arg;
 use environ::Env;
 use nix::{
     sys::stat::{umask, Mode},
     unistd::daemon,
 };
+use std::io::Read;
+use std::time::{SystemTime, UNIX_EPOCH};
 use std::{
     env, fs,
     fs::OpenOptions,
@@ -12,7 +13,6 @@ use std::{
     path::Path,
     process::{exit, id, Command, Stdio},
 };
-use std::time::{SystemTime, UNIX_EPOCH};
 use sysinfo::{ProcessExt, System, SystemExt};
 
 mod environ;


### PR DESCRIPTION
This PR implements the following changes, these changes have been limited to `swhks` for feedback and review, but they can be extended into the actual `swhkd` as well.

### 1. Env Struct
The env struct is used to centrally handle all the environment related queries and initializations. It is opened as a thread safe `OnceLock` variable and hence is ideal for servers

### 2. Better Error Handling
Error handling related to env is now centrally handled in the Env struct itself using typecasted enumerations

### 3. PathBuf implementations
Paths are now handled with `pathbufs` instead of format strings

This PR lays the ground work in centralizing the Environment variable queries that would help abstract away all the individual queries. This could especially be helpful when we modify the privilege model since we would now need to do changes in only a few places

Additionally, this has been tested individually and cargo linted as well

Feedback and any changes required are appreciated 😄  