### PR TITLE
refactor: move `send_command` macro into a function

### DIFF
--- a/swhkd/src/daemon.rs
+++ b/swhkd/src/daemon.rs
@@ -1,6 +1,6 @@
 use crate::config::Value;
-use config::Hotkey;
 use clap::Parser;
+use config::Hotkey;
 use evdev::{AttributeSet, Device, InputEventKind, Key};
 use nix::{
     sys::stat::{umask, Mode},


### PR DESCRIPTION
The `send_command` macro in SWHKD's `daemon.rs` component accepts expressions with the same datatype in all invocations. Moving it into a function helps language servers like Rust Analyzer make inferences easier because the expressions become concrete types.