### PR TITLE
refactor: do not clone configs `Vec` for unprocessed imports

### DIFF
--- a/swhkd/src/config.rs
+++ b/swhkd/src/config.rs
@@ -103,18 +103,18 @@ impl Config {
 
     pub fn load_and_merge(config: Self) -> Result<Vec<Self>, Error> {
         let mut configs = vec![config];
-        let mut prev_count = 0;
-        let mut current_count = configs.len();
-        while prev_count != current_count {
-            prev_count = configs.len();
-            for config in configs.clone() {
-                for import in Self::load_to_configs(&config)? {
+        let mut processed = 0;
+
+        while processed != configs.len() {
+            let unprocessed_range = processed..configs.len();
+            for unprocessed in unprocessed_range {
+                for import in Self::load_to_configs(&configs[unprocessed])? {
                     if !configs.contains(&import) {
                         configs.push(import);
                     }
                 }
+                processed += 1;
             }
-            current_count = configs.len();
         }
         Ok(configs)
     }


### PR DESCRIPTION
### Changes
- Each iteration of a load inside the `load_and_merge` function only considers new elements since the last round.
- The entire `configs` vector does not need to be cloned for working on the small tail slice of unprocessed configs.