### PR TITLE
feat: add ability to list devices and fuzzy match their names

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -10,6 +10,7 @@ dependencies = [
  "env_logger",
  "evdev",
  "flate2",
+ "fuzzy-matcher",
  "itertools",
  "log",
  "nix",
@@ -296,6 +297,15 @@ name = "futures-core"
 version = "0.3.25"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "04909a7a7e4633ae6c4a9ab280aeb86da1236243a77b694a49eacd659a4bd3ac"
+
+[[package]]
+name = "fuzzy-matcher"
+version = "0.3.7"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "54614a3312934d066701a80f20f15fa3b56d67ac7722b39eea5b4c9dd1d66c94"
+dependencies = [
+ "thread_local",
+]
 
 [[package]]
 name = "heck"
@@ -692,6 +702,16 @@ dependencies = [
  "proc-macro2",
  "quote",
  "syn 1.0.107",
+]
+
+[[package]]
+name = "thread_local"
+version = "1.1.8"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8b9ef9bad013ada3808854ceac7b46812a6465ba368859a37e2100283d2d719c"
+dependencies = [
+ "cfg-if",
+ "once_cell",
 ]
 
 [[package]]

--- a/swhkd/Cargo.toml
+++ b/swhkd/Cargo.toml
@@ -16,6 +16,7 @@ flate2 = "1.0.24"
 clap = { version = "4.1.0", features = ["derive"] }
 env_logger = "0.9.0"
 evdev = { version = "0.12.0", features = ["tokio"] }
+fuzzy-matcher = "0.3.7"
 itertools = "0.10.3"
 log = "0.4.14"
 nix = "0.23.1"


### PR DESCRIPTION
### Changes
- The daemon is broken into the `run` and `list-devices` subcommand
- The `list-devices` subcommand displays the paths and names (if available) of available devices
- The `--device` flag now only expects absolute paths to devices (like `/dev/input/event0`)
- The `--device-by-name` flag expects a string that fuzzy matches to the name of one of the available devices