### PR TITLE
upgrade libc to 0.2.159

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -424,9 +424,9 @@ dependencies = [
 
 [[package]]
 name = "libc"
-version = "0.2.155"
+version = "0.2.159"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "97b3888a4aecf77e811145cadf6eef5901f4782c53886191b2f693f24761847c"
+checksum = "561d97a539a36e26a9a5fad1ea11a3039a67714694aaa379433e580854bc3dc5"
 
 [[package]]
 name = "libudev-sys"


### PR DESCRIPTION
Build was failing on alpine for loongarch64.

https://build.alpinelinux.org/buildlogs/build-edge-loongarch64/testing/swhkd/swhkd-1.2.1-r0.log

libc 0.2.159 adds support for loongarch64