### PR TITLE
deps: bump sweet

### DIFF
--- a/swhkd/Cargo.toml
+++ b/swhkd/Cargo.toml
@@ -21,7 +21,7 @@ log = "0.4.14"
 nix = "0.23.1"
 signal-hook = "0.3.13"
 signal-hook-tokio = { version = "0.3.1", features = ["futures-v0_3"] }
-sweet = { git = "https://github.com/waycrate/sweet.git", version = "0.3.0" }
+sweet = { git = "https://github.com/waycrate/sweet.git", version = "0.4.0" }
 sysinfo = "0.23.5"
 tokio = { version = "1.24.2", features = ["full"] }
 tokio-stream = "0.1.8"


### PR DESCRIPTION
Fixes https://github.com/waycrate/sweet/issues/1

### Changes to SWHKD
- Bumped dependency sweet to 0.4.0

### Changes to sweet
- Reorder conflicting keys in descending order to avoid greedy parsing of shorter variants