### PR TITLE
[Fix] Clear the buffer before reading again, fixes #279

### DIFF
--- a/swhkd/src/daemon.rs
+++ b/swhkd/src/daemon.rs
@@ -698,6 +698,9 @@ pub fn refresh_env(
             log::error!("Failed to write to socket.");
             return Ok((None, prev_hash));
         }
+
+        // Clear the buffer before reading
+        buff.clear();
         stream.read_to_string(&mut buff)?;
     }
 


### PR DESCRIPTION
# Fixes the invalid environment variable issue
There was hash prepended to the actual environment variables string received from swhks
since [UnixStream::read_to_string](https://doc.rust-lang.org/std/os/unix/net/struct.UnixStream.html#method.read_to_string-1) method is append to buffer instead of overwriting, the result of previous read still persists in the buffer resulting in invalid variable.

This happens when the previous hash do not match and hence request for latest variables is made to swhks and read into the same buffer hash was read in (which appends).
# Fix
clear the buffer before reading next string.


Fixes  #279 