### PR TITLE
chore: updates cargo.lock

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -767,8 +767,8 @@ checksum = "7da8b5736845d9f2fcb837ea5d9e2628564b3b043a70948a3f0b778838c5fb4f"
 
 [[package]]
 name = "sweet"
-version = "0.3.0"
-source = "git+https://github.com/waycrate/sweet.git#a91d1ab6fb7988578ce359cfbf55e75b813d84db"
+version = "0.4.0"
+source = "git+https://github.com/waycrate/sweet.git#797d88bfefe8242b96da6b20afa40d489d3ec076"
 dependencies = [
  "anyhow",
  "bitflags 2.6.0",


### PR DESCRIPTION
# Updates sweet to 0.4.0 in cargo.lock
should fix swhkd-git aur package failing to build, issue #281 