### PR TITLE
Enhancement: swhkd binary should never read environment

### DIFF
--- a/swhkd/src/daemon.rs
+++ b/swhkd/src/daemon.rs
@@ -91,8 +91,8 @@ async fn main() -> Result<(), Box<dyn Error>> {
     // Without this request, the environmental variables responsible for the reading for the config
     // file will not be available.
     // Thus, it is important to wait for the server to start before proceeding.
-    let mut env = environ::Env::construct(None);
-    let mut env_hash = 0;
+    let env;
+    let mut env_hash;
     loop {
         match refresh_env(invoking_uid, 0) {
             Ok((Some(new_env), hash)) => {
@@ -100,8 +100,7 @@ async fn main() -> Result<(), Box<dyn Error>> {
                 env = new_env;
                 break;
             }
-            Ok((None, hash)) => {
-                env_hash = hash;
+            Ok((None, _)) => {
                 log::debug!("Waiting for env...");
                 continue;
             }

--- a/swhkd/src/environ.rs
+++ b/swhkd/src/environ.rs
@@ -1,4 +1,4 @@
-use std::{collections::HashMap, error::Error, path::PathBuf, process::Command};
+use std::{collections::HashMap, path::PathBuf};
 
 #[derive(Debug, Clone)]
 pub struct Env {
@@ -6,12 +6,6 @@ pub struct Env {
 }
 
 impl Env {
-    fn get_env() -> Result<String, Box<dyn Error>> {
-        let cmd = Command::new("env").output()?;
-        let stdout = String::from_utf8(cmd.stdout)?;
-        Ok(stdout)
-    }
-
     fn parse_env(env: &str) -> HashMap<String, String> {
         let mut pairs = HashMap::new();
         for line in env.lines() {
@@ -27,7 +21,7 @@ impl Env {
     pub fn construct(env: Option<&str>) -> Self {
         let env = match env {
             Some(env) => env.to_string(),
-            None => Self::get_env().unwrap(),
+            None => "".to_string(),
         };
         let pairs = Self::parse_env(&env);
         Self { pairs }


### PR DESCRIPTION
Since swhkd runs in elevated perms, at no time it should capture the environment variables. 
Currently the call to `environ::Env::construct(None)` is made to initialize env, which captures the environment of swhkd although this is always overwritten it could lead to security issues so its better to initialize it empty