### PR TITLE
Enhancement: Better error reporting on invalid config files

### DIFF
--- a/swhkd/src/config.rs
+++ b/swhkd/src/config.rs
@@ -4,7 +4,7 @@ use sweet::{Definition, SwhkdParser};
 use sweet::{ModeInstruction, ParseError};
 
 pub fn load(path: &Path) -> Result<Vec<Mode>, ParseError> {
-    let config_self = sweet::SwhkdParser::from(sweet::ParserInput::Path(path)).unwrap();
+    let config_self = sweet::SwhkdParser::from(sweet::ParserInput::Path(path))?;
     parse_contents(config_self)
 }
 


### PR DESCRIPTION
Improves error reporting when config parsing related errors
This along with [this pr](https://github.com/waycrate/sweet/pull/2) will allows pest error to be visible when config file parsing fails

Current Output
```
thread 'main' panicked at swhkd/src/config.rs:7:80:
called `Result::unwrap()` on an `Err` value: Grammar(Error { variant: ParsingError { positives: [command], negatives: [] }, location: Pos(9), line_col: Pos((1, 10)), path: Some("/home/manth/swhkdrc"), line: "super + a; f ", continued_line: None, parse_attempts: None })
note: run with `RUST_BACKTRACE=1` environment variable to display a backtrace
```
New output
```
[2025-01-11T20:39:07Z ERROR swhkd] Config Error: unable to parse config file
```
New output after sweet with [this pr](https://github.com/waycrate/sweet/pull/2)
```
[2025-01-11T20:42:57Z ERROR swhkd] Config Error:
     --> /home/manth/swhkdrc:1:10
      |
    1 | super + a; f
      |          ^---
      |
      = expected command
    Unable to parse config file

```
for reference  #287 