### PR TITLE
fix: display error source for grammar errors if they exist

### DIFF
--- a/swhkd/src/config.rs
+++ b/swhkd/src/config.rs
@@ -4,7 +4,7 @@ use sweet::{Definition, SwhkdParser};
 use sweet::{ModeInstruction, ParseError};
 
 pub fn load(path: &Path) -> Result<Vec<Mode>, ParseError> {
-    let config_self = sweet::SwhkdParser::from(sweet::ParserInput::Path(path)).unwrap();
+    let config_self = sweet::SwhkdParser::from(sweet::ParserInput::Path(path))?;
     parse_contents(config_self)
 }
 

--- a/swhkd/src/daemon.rs
+++ b/swhkd/src/daemon.rs
@@ -247,6 +247,9 @@ async fn main() -> Result<(), Box<dyn Error>> {
         match config::load(&config_file_path) {
             Err(e) => {
                 log::error!("Config Error: {}", e);
+                if let Some(error_source) = e.source() {
+                    log::error!("{}", error_source);
+                }
                 exit(1)
             }
             Ok(out) => out,


### PR DESCRIPTION
The new logging system seems to discard the source of a grammar error.
Fixed that by checking and displaying the error if it exists.
