### PR TITLE
[fix] spelling error in Cargo.toml

### DIFF
--- a/swhkd/Cargo.toml
+++ b/swhkd/Cargo.toml
@@ -1,5 +1,5 @@
 [package]
-description = "Sxhkd clone for Wayland (works on TYY and X11 too)"
+description = "Sxhkd clone for Wayland (works on TTY and X11 too)"
 edition = "2021"
 name = "Simple-Wayland-HotKey-Daemon"
 version = "1.3.0-dev"


### PR DESCRIPTION
fix spelling mistake in Cargo.toml:
changed `TYY` to `TTY`