### PR TITLE
Fix: Added rfkill support as a feature flag

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -767,8 +767,8 @@ checksum = "7da8b5736845d9f2fcb837ea5d9e2628564b3b043a70948a3f0b778838c5fb4f"
 
 [[package]]
 name = "sweet"
-version = "0.3.0"
-source = "git+https://github.com/waycrate/sweet.git#a91d1ab6fb7988578ce359cfbf55e75b813d84db"
+version = "0.4.0"
+source = "git+https://github.com/waycrate/sweet.git#797d88bfefe8242b96da6b20afa40d489d3ec076"
 dependencies = [
  "anyhow",
  "bitflags 2.6.0",

--- a/INSTALL.md
+++ b/INSTALL.md
@@ -6,7 +6,7 @@ We have packaged `swhkd-git`. `swhkd-bin` has been packaged separately by a user
 
 `swhkd` and `swhks` install to `/usr/local/bin/` by default. You can change this behaviour by editing the [Makefile](../Makefile) variable, `DESTDIR`, which acts as a prefix for all installed files. You can also specify it in the make command line, e.g. to install everything in `subdir`: `make DESTDIR="subdir" install`.
 
-Note: On some systems swhkd daemon might disable wifi due to issues with rfkill, you could pass `make NO_DEFAULT_FEATURES=1` while buliding to disable rfkill support.
+Note: On some systems swhkd daemon might disable wifi due to issues with rfkill, you could pass `make NO_RFKILL_SW_SUPPORT=1` while buliding to disable rfkill support.
 
 # Dependencies:
 

--- a/INSTALL.md
+++ b/INSTALL.md
@@ -6,6 +6,8 @@ We have packaged `swhkd-git`. `swhkd-bin` has been packaged separately by a user
 
 `swhkd` and `swhks` install to `/usr/local/bin/` by default. You can change this behaviour by editing the [Makefile](../Makefile) variable, `DESTDIR`, which acts as a prefix for all installed files. You can also specify it in the make command line, e.g. to install everything in `subdir`: `make DESTDIR="subdir" install`.
 
+Note: On some systems swhkd daemon might disable wifi due to issues with rfkill, you could pass `make NO_DEFAULT_FEATURES=1` while buliding to disable rfkill support.
+
 # Dependencies:
 
 **Runtime:**

--- a/Makefile
+++ b/Makefile
@@ -9,8 +9,8 @@ MAN1_DIR := /usr/share/man/man1
 MAN5_DIR := /usr/share/man/man5
 VERSION = $(shell awk -F ' = ' '$$1 ~ /version/ { gsub(/["]/, "", $$2); printf("%s",$$2) }' Cargo.toml)
 
-ifneq ($(NO_DEFAULT_FEATURES),)
-    BUILDFLAGS += --no-default-features
+ifneq ($(NO_RFKILL_SW_SUPPORT),)
+	BUILDFLAGS += --features "no_rfkill"
 endif
 
 all: build

--- a/Makefile
+++ b/Makefile
@@ -9,6 +9,10 @@ MAN1_DIR := /usr/share/man/man1
 MAN5_DIR := /usr/share/man/man5
 VERSION = $(shell awk -F ' = ' '$$1 ~ /version/ { gsub(/["]/, "", $$2); printf("%s",$$2) }' Cargo.toml)
 
+ifneq ($(NO_DEFAULT_FEATURES),)
+    BUILDFLAGS += --no-default-features
+endif
+
 all: build
 
 build:

--- a/contrib/PKGBUILD
+++ b/contrib/PKGBUILD
@@ -4,7 +4,7 @@
 
 _pkgname="swhkd"
 pkgname="${_pkgname}-git"
-pkgver=1.2.1.r91.gde8d627
+pkgver=1.2.1.r92.ge972f55
 pkgrel=1
 arch=("x86_64")
 url="https://github.com/waycrate/swhkd"
@@ -21,7 +21,7 @@ sha256sums=("SKIP"
 build(){
 	cd "$_pkgname"
 	make setup
-	make NO_DEFAULT_FEATURES=1
+	make NO_RFKILL_SW_SUPPORT=1
 }
 
 package() {

--- a/contrib/PKGBUILD
+++ b/contrib/PKGBUILD
@@ -4,7 +4,7 @@
 
 _pkgname="swhkd"
 pkgname="${_pkgname}-git"
-pkgver=1.2.1.r17.g022466e
+pkgver=1.2.1.r91.gde8d627
 pkgrel=1
 arch=("x86_64")
 url="https://github.com/waycrate/swhkd"
@@ -21,7 +21,7 @@ sha256sums=("SKIP"
 build(){
 	cd "$_pkgname"
 	make setup
-	make
+	make NO_DEFAULT_FEATURES=1
 }
 
 package() {

--- a/swhkd/Cargo.toml
+++ b/swhkd/Cargo.toml
@@ -12,6 +12,10 @@ authors = [
 [build-dependencies]
 flate2 = "1.0.24"
 
+[features]
+rfkill = []
+default = ["rfkill"]
+
 [dependencies]
 clap = { version = "4.1.0", features = ["derive"] }
 env_logger = "0.9.0"

--- a/swhkd/Cargo.toml
+++ b/swhkd/Cargo.toml
@@ -13,8 +13,7 @@ authors = [
 flate2 = "1.0.24"
 
 [features]
-rfkill = []
-default = ["rfkill"]
+no_rfkill = []
 
 [dependencies]
 clap = { version = "4.1.0", features = ["derive"] }

--- a/swhkd/src/uinput.rs
+++ b/swhkd/src/uinput.rs
@@ -3,14 +3,14 @@ use evdev::{
     AttributeSet, Key, RelativeAxisType, SwitchType,
 };
 
-#[cfg(feature = "rfkill")]
+#[cfg(not(feature = "no_rfkill"))]
 use nix::ioctl_none;
-#[cfg(feature = "rfkill")]
+#[cfg(not(feature = "no_rfkill"))]
 use std::fs::File;
-#[cfg(feature = "rfkill")]
+#[cfg(not(feature = "no_rfkill"))]
 use std::os::unix::io::AsRawFd;
 
-#[cfg(feature = "rfkill")]
+#[cfg(not(feature = "no_rfkill"))]
 ioctl_none!(rfkill_noinput, b'R', 1);
 
 pub fn create_uinput_device() -> Result<VirtualDevice, Box<dyn std::error::Error>> {
@@ -41,7 +41,7 @@ pub fn create_uinput_switches_device() -> Result<VirtualDevice, Box<dyn std::err
     // fast enough that it won't impact anyone. rfkill-input will be enabled
     // again when the file gets closed.
     // Implemented as feature for it causes issues with radio on some platforms.
-    #[cfg(feature = "rfkill")]
+    #[cfg(not(feature = "no_rfkill"))]
     {
         let rfkill_file = File::open("/dev/rfkill")?;
         unsafe {
@@ -631,7 +631,7 @@ pub fn get_all_switches() -> &'static [SwitchType] {
         SwitchType::SW_LID,
         SwitchType::SW_TABLET_MODE,
         SwitchType::SW_HEADPHONE_INSERT,
-        #[cfg(feature = "rfkill")]
+        #[cfg(not(feature = "no_rfkill"))]
         SwitchType::SW_RFKILL_ALL,
         SwitchType::SW_MICROPHONE_INSERT,
         SwitchType::SW_DOCK,


### PR DESCRIPTION
Combines this commit [commit](https://github.com/waycrate/swhkd/commit/9701b3f787d2e546cb4837d330cd7037e78f4665l) and #254 .
works on arch linux with mediatek MT7921 wifi module. 
wifi stops resting as expected with --no-default-features flags, although i am not able to test with a rfkill switch yet