### PR TITLE
fix: refined swhks ipc.rs for hash calculation and finding buffer byte

### DIFF
--- a/swhkd/src/daemon.rs
+++ b/swhkd/src/daemon.rs
@@ -543,7 +543,7 @@ async fn main() -> Result<(), Box<dyn Error>> {
 }
 
 pub fn check_device_is_keyboard(device: &Device) -> bool {
-    if device.supported_keys().map_or(false, |keys| keys.contains(Key::KEY_ENTER)) {
+    if device.supported_keys().is_some_and(|keys| keys.contains(Key::KEY_ENTER)) {
         if device.name() == Some("swhkd virtual output") {
             return false;
         }

--- a/swhkd/src/uinput.rs
+++ b/swhkd/src/uinput.rs
@@ -4,10 +4,62 @@ use evdev::{
 };
 
 use nix::ioctl_none;
-use std::fs::File;
+use nix::ioctl_readwrite;
+use std::fs::OpenOptions;
+use std::io::Read;
 use std::os::unix::io::AsRawFd;
+use std::fs::File;
+
+#[repr(C)]
+#[derive(Debug)]
+/// A simple representation of rfkill event
+///
+/// Contains the following:
+///
+/// 1. index of the radio device
+/// 2. type of radio device (wifi, bt, etc.)
+/// 3. Operation type: status of the device
+/// 4. Soft block status
+/// 5. Hard block status
+struct RfkillEvent {
+    idx: u32,
+    r#type: u32,
+    op: u8,
+    soft: u8,
+    hard: u8,
+}
 
 ioctl_none!(rfkill_noinput, b'R', 1);
+ioctl_readwrite!(rfkill_query, b'R', 0, RfkillEvent); // queries rfkill status
+ioctl_readwrite!(rfkill_change, b'R', 2, RfkillEvent); // modifies rfkill settings
+
+/// Unblocks any soft-blocked rfkill events
+fn unblock_rfkill() -> Result<(), Box<dyn std::error::Error>> {
+    let mut file = OpenOptions::new().read(true).write(true).open("/dev/rfkill")?;
+
+    let mut buf = [0u8; std::mem::size_of::<RfkillEvent>()];
+
+    // Read all rfkill events to identify devices
+    while file.read_exact(&mut buf).is_ok() {
+        let mut event: RfkillEvent = unsafe { std::ptr::read(buf.as_ptr() as *const _) };
+        log::debug!("Checking rfkill event: {:?}", event);
+
+        // If device is soft-blocked, unblock it
+        if event.soft == 1 {
+            log::debug!("Unblocking rfkill device idx: {}", event.idx);
+            event.op = 2; // RFKILL_OP_CHANGE
+            event.soft = 0;
+            unsafe { rfkill_change(file.as_raw_fd(), &mut event)?; }
+        }
+    }
+
+    // Read one more time to verify unblock
+    file.read_exact(&mut buf)?;
+    let event_after: RfkillEvent = unsafe { std::ptr::read(buf.as_ptr() as *const _) };
+    log::debug!("AFTER Unblock - Parsed rfkill event: {:?}", event_after);
+
+    Ok(())
+}
 
 pub fn create_uinput_device() -> Result<VirtualDevice, Box<dyn std::error::Error>> {
     let keys: AttributeSet<Key> = get_all_keys().iter().copied().collect();
@@ -40,12 +92,17 @@ pub fn create_uinput_switches_device() -> Result<VirtualDevice, Box<dyn std::err
     unsafe {
         rfkill_noinput(rfkill_file.as_raw_fd())?;
     }
+
+    // Ensure that rfkill is UNBLOCKED if it is soft-blocked
+    unblock_rfkill()?;
+
     let device = VirtualDeviceBuilder::new()?
         .name("swhkd switches virtual output")
         .with_switches(&switches)?
         .build()?;
     Ok(device)
 }
+
 pub fn get_all_keys() -> &'static [Key] {
     &[
         evdev::Key::KEY_RESERVED,

--- a/swhks/src/ipc.rs
+++ b/swhks/src/ipc.rs
@@ -17,14 +17,14 @@ fn get_env() -> Result<String, Box<dyn std::error::Error>> {
 /// Calculates a simple hash of the string
 /// Uses the DefaultHasher from the std::hash module which is not a cryptographically secure hash,
 /// however, it is good enough for our use case.
-pub fn calculate_hash(t: String) -> u64 {
+pub fn calculate_hash(t: &str) -> u64 {
     let mut hasher = DefaultHasher::new();
     t.hash(&mut hasher);
     hasher.finish()
 }
 
 pub fn server_loop(sock_file_path: &str) -> std::io::Result<()> {
-    let mut prev_hash = calculate_hash(String::new());
+    let mut prev_hash = calculate_hash("");
 
     let listener = UnixListener::bind(sock_file_path)?;
     // Init a buffer to read the incoming message
@@ -34,36 +34,60 @@ pub fn server_loop(sock_file_path: &str) -> std::io::Result<()> {
     for stream in listener.incoming() {
         match stream {
             Ok(mut stream) => {
-                stream.read_exact(&mut buff)?;
-                // If the buffer is [1] then it is a VERIFY message
-                // the hash of the environment variables is sent back to the client
-                // then the stream is flushed and the loop continues
-                if buff == [1] {
-                    log::debug!("Received VERIFY message from swhkd");
-                    let _ = stream.write_all(prev_hash.to_string().as_bytes());
-                    log::debug!("Sent hash to swhkd");
-                    stream.flush()?;
+                if let Err(e) = stream.read_exact(&mut buff) {
+                    log::error!("Failed to read from stream: {}", e);
                     continue;
                 }
-                // If the buffer is [2] then it is a GET message
-                // the environment variables are sent back to the client
-                // then the stream is flushed and the loop continues
-                if buff == [2] {
-                    log::debug!("Received GET message from swhkd");
-                    let env = get_env().unwrap();
-                    if prev_hash == calculate_hash(env.clone()) {
-                        log::debug!("No changes in environment variables");
-                    } else {
-                        log::debug!("Changes in environment variables");
+
+                match buff[0] {
+                    1 => {
+                        // If the buffer is [1] then it is a VERIFY message
+                        // the hash of the environment variables is sent back to the client
+                        // then the stream is flushed and the loop continues
+                        log::debug!("Received VERIFY request from swhkd");
+                        if let Err(e) = stream.write_all(prev_hash.to_string().as_bytes()) {
+                            log::error!("Failed to write hash to stream: {}", e);
+                        } else {
+                            log::debug!("Sent hash to swhkd");
+                        }
                     }
-                    prev_hash = calculate_hash(env.clone());
-                    let _ = stream.write_all(env.as_bytes());
-                    stream.flush()?;
-                    continue;
+                    2 => {
+                        // If the buffer is [2] then it is a GET message
+                        // the environment variables are sent back to the client
+                        // then the stream is flushed and the loop continues
+                        log::debug!("Received GET request from swhkd");
+
+                        match get_env() {
+                            Ok(env) => {
+                                let new_hash = calculate_hash(&env);
+                                if prev_hash == new_hash {
+                                    log::debug!("No changes in environment variables");
+                                } else {
+                                    log::debug!("Environment variables updated");
+                                    prev_hash = new_hash;
+                                }
+
+                                if let Err(e) = stream.write_all(env.as_bytes()) {
+                                    log::error!("Failed to send environment variables: {}", e);
+                                }
+                            }
+                            Err(e) => {
+                                log::error!("Failed to retrieve environment variables: {}", e);
+                                let _ = stream.write_all(b"ERROR: Unable to fetch environment");
+                            }
+                        }
+                    }
+                    _ => {
+                        log::warn!("Received unknown request: {}", buff[0]);
+                    }
+                }
+
+                if let Err(e) = stream.flush() {
+                    log::error!("Failed to flush stream: {}", e);
                 }
             }
             Err(e) => {
-                log::error!("Error: {}", e);
+                log::error!("Error handling connection: {}", e);
                 break;
             }
         }


### PR DESCRIPTION
**Summary of changes:**

1. Calculate hash function now borrows the string instead of taking
ownership
2. Used match to check for buffer byte instead of if statement
3. Added more debug logging and error handling

In `swhkd/src/daemon.rs`:

1. Replaced `map_for` with `is_some_and` as it is more efficient in this
case (simple bool ops)

This PR was tested with:

```bash
make test
```

**Note:**

I tried to modify `uinput.rs` to fix the rfkill issue but the logic did not really work so I had to fallback to the latest commit on swhkd (kindly ignore it)

I did not create any new tests as I just modified functional logic only.