### PR TITLE
Fix hot swhkd loop

### DIFF
--- a/swhkd/src/daemon.rs
+++ b/swhkd/src/daemon.rs
@@ -195,8 +195,8 @@ async fn main() -> Result<(), Box<dyn Error>> {
             let log = log.clone();
 
             // Set the user and group id to the invoking user for the thread
-            setgid(Gid::from_raw(invoking_uid)).unwrap();
-            setuid(Uid::from_raw(invoking_uid)).unwrap();
+            setuid(Uid::from_raw(invoking_uid)).expect(&format!("Failed to set group-id to {}", invoking_uid));
+            setgid(Gid::from_raw(invoking_uid)).expect(&format!("Failed to set user-id to {}", invoking_uid));
 
             // Command execution
             let mut cmd = Command::new("sh");
@@ -650,6 +650,11 @@ pub async fn send_command(
 fn get_uid() -> Result<u32, Box<dyn Error>> {
     let status_content = fs::read_to_string(format!("/proc/{}/loginuid", std::process::id()))?;
     let uid = status_content.trim().parse::<u32>()?;
+    if uid == u32::MAX {
+        return Err("got invalid loginuid value 4294967295 ('-1' in unsigned long), meaning loginuid is unset. \
+        This can happen e.g. if you run the application as a service but don't explicitly configure a user to run it as".into());
+    }
+
     Ok(uid)
 }
 

--- a/swhkd/src/daemon.rs
+++ b/swhkd/src/daemon.rs
@@ -86,7 +86,12 @@ async fn main() -> Result<(), Box<dyn Error>> {
     // Get the UID of the user that is not a system user
     let invoking_uid = get_uid()?;
 
-    log::debug!("Wating for server to start...");
+    // Calculate a server cooldown at which the server will be pinged to check for env changes.
+    let cooldown = args.cooldown;
+    let delta = (cooldown as f64 * 0.1) as u64;
+    let server_cooldown = std::cmp::max(0, cooldown - delta);
+
+    log::debug!("Waiting for swhks socket...");
     // The first and the most important request for the env
     // Without this request, the environmental variables responsible for the reading for the config
     // file will not be available.
@@ -101,7 +106,7 @@ async fn main() -> Result<(), Box<dyn Error>> {
                 break;
             }
             Ok((None, _)) => {
-                log::debug!("Waiting for env...");
+                sleep(Duration::from_millis(server_cooldown)).await;
                 continue;
             }
             Err(_) => {}
@@ -141,11 +146,6 @@ async fn main() -> Result<(), Box<dyn Error>> {
         }
         fs::set_permissions(&log_path, Permissions::from_mode(0o666)).unwrap();
     }
-
-    // Calculate a server cooldown at which the server will be pinged to check for env changes.
-    let cooldown = args.cooldown;
-    let delta = (cooldown as f64 * 0.1) as u64;
-    let server_cooldown = std::cmp::max(0, cooldown - delta);
 
     // Set up a channel to communicate with the server
     // The channel can have upto 100 commands in the queue

--- a/swhkd/src/daemon.rs
+++ b/swhkd/src/daemon.rs
@@ -675,13 +675,20 @@ pub fn refresh_env(
 
     // Follows a two part process to recieve the env hash and the env itself
     // First part: Send a "1" as a byte to the socket to request the hash
-    if let Ok(mut stream) = UnixStream::connect(&sock_path) {
-        let n = stream.write(&[1])?;
-        if n != 1 {
-            log::error!("Failed to write to socket.");
+    log::debug!("reading from socket {}", sock_path);
+    match UnixStream::connect(&sock_path) {
+        Ok(mut stream) => {
+            let n = stream.write(&[1])?;
+            if n != 1 {
+                log::error!("Failed to write to socket {}", sock_path);
+                return Ok((None, prev_hash));
+            }
+            stream.read_to_string(&mut buff)?;
+        }
+        Err(e) => {
+            log::warn!("Failed to connect to socket {}: {}", sock_path, e);
             return Ok((None, prev_hash));
         }
-        stream.read_to_string(&mut buff)?;
     }
 
     let env_hash = buff.parse().unwrap_or_default();


### PR DESCRIPTION
This should resolve https://github.com/waycrate/swhkd/issues/317.

The actual fix:
- add delay to socket-connection attempts, so we don't cause unnecessary CPU load (this required pulling up the cooldown-calculation logic).

Misc changes:
- removed the "waiting for..." log, as it's kind of redundant with the log before the loop + the next change
- socket connection errors are no longer ignored, instead a warning with the cause is logged. I think 'warning' is fitting here, as this error gets retried by the loops that call this function
- add more context to panics during `set_uid`/`_pid` calls. The original panic message is only useful with code at hand.
- `get_uid` now returns an error in case `loginuid` is unset, instead of running into calls like `set_uid` with invalid values (which then cause a panic)

The misc changes are of course not relevant for the referenced issue, but they helped me a lot to understand what's wrong with my systemd service setup. If you're unhappy with those changes, I can of course drop them.

Side-Note regarding the "socket connection warning": It's kinda bad that the log-level down there is a result of how the loop further up behaves. I think it'd be better to pass an (enriched) error up, and let the loop decide what to with it. But I didn't want to introduce more changes, also because this is my very first time looking into Rust.